### PR TITLE
Update General.lua

### DIFF
--- a/modules/SlashCommands/General.lua
+++ b/modules/SlashCommands/General.lua
@@ -98,7 +98,7 @@ function SlashCommands.SlashCampaignQ(option)
     end
 
     -- Compare names to campaigns available, join the campaign and bail out of the function if it is available.
-    for i = 1, 100 do
+    for i = 1, 124 do
         local compareName = string.lower(GetCampaignName(i))
         local option = string.lower(option)
         if compareName == option then


### PR DESCRIPTION
Campaigns now extend to 124. It'd be wise to map the campaign names to indexes once per session instead of iterating over them everytime join is issued but anyway, this is not something happening a lot during the execution.