### PR TITLE
Fixes for Arcanist Color in UnitFrames

### DIFF
--- a/modules/UnitFrames/UnitFrames.lua
+++ b/modules/UnitFrames/UnitFrames.lua
@@ -3847,7 +3847,7 @@ function UnitFrames.CustomFramesApplyColours(isMenu)
     local class4_bg  = { 0.1*UnitFrames.SV.CustomColourWarden[1], 0.1*UnitFrames.SV.CustomColourWarden[2], 0.1*UnitFrames.SV.CustomColourWarden[3], 0.9} -- Warden
     local class5_bg  = { 0.1*UnitFrames.SV.CustomColourNecromancer[1], 0.1*UnitFrames.SV.CustomColourNecromancer[2], 0.1*UnitFrames.SV.CustomColourNecromancer[3], 0.9} -- Necromancer
     local class6_bg  = { 0.1*UnitFrames.SV.CustomColourTemplar[1], 0.1*UnitFrames.SV.CustomColourTemplar[2], 0.1*UnitFrames.SV.CustomColourTemplar[3], 0.9} -- Templar
-    local class117_bg = { 0.1 * UnitFrames.SV.CustomColourArcanist[1], 0.1 * UnitFrames.SV.CustomColourArcanist[2], 0.1 * UnitFrames.SV.CustomColourArcanist[3], 0.9 } -- Arcanist
+    local class117_bg = { 0.1*UnitFrames.SV.CustomColourArcanist[1], 0.1*UnitFrames.SV.CustomColourArcanist[2], 0.1*UnitFrames.SV.CustomColourArcanist[3], 0.9 } -- Arcanist
 
     local petcolor_bg = { 0.1*UnitFrames.SV.CustomColourPet[1], 0.1*UnitFrames.SV.CustomColourPet[2], 0.1*UnitFrames.SV.CustomColourPet[3], 0.9} -- Player Pet
     local companioncolor_bg = { 0.1*UnitFrames.SV.CustomColourCompanionFrame[1], 0.1*UnitFrames.SV.CustomColourCompanionFrame[2], 0.1*UnitFrames.SV.CustomColourCompanionFrame[3], 0.9} -- Companion
@@ -4160,7 +4160,7 @@ function UnitFrames.CustomFramesApplyReactionColor(isPlayer)
             [4]  = { 0.1*UnitFrames.SV.CustomColourWarden[1], 0.1*UnitFrames.SV.CustomColourWarden[2], 0.1*UnitFrames.SV.CustomColourWarden[3], 0.9}, -- Warden
             [5]  = { 0.1*UnitFrames.SV.CustomColourNecromancer[1], 0.1*UnitFrames.SV.CustomColourNecromancer[2], 0.1*UnitFrames.SV.CustomColourNecromancer[3], 0.9}, -- Necromancer
             [6]  = { 0.1*UnitFrames.SV.CustomColourTemplar[1], 0.1*UnitFrames.SV.CustomColourTemplar[2], 0.1*UnitFrames.SV.CustomColourTemplar[3], 0.9}, -- Templar
-            [117]  = { UnitFrames.SV.CustomColourTemplar[1], UnitFrames.SV.CustomColourArcanist[2], UnitFrames.SV.CustomColourArcanist[3], 0.9}, -- Arcanist
+            [117]  = { 0.1*UnitFrames.SV.CustomColourArcanist[1], 0.1*UnitFrames.SV.CustomColourArcanist[2], 0.1*UnitFrames.SV.CustomColourArcanist[3], 0.9}, -- Arcanist
         }
 
         if UnitFrames.CustomFrames["reticleover"] then

--- a/settings/UnitFrames.lua
+++ b/settings/UnitFrames.lua
@@ -717,7 +717,7 @@ function UnitFrames.CreateSettings()
                 name = GetString(SI_LUIE_LAM_UF_CFRAMES_COLOR_ARCA),
                 getFunc = function() return unpack(Settings.CustomColourArcanist) end,
                 setFunc = function(r, g, b, a)
-                    Settings.CustomColourArcanst = { r, g, b }
+                    Settings.CustomColourArcanist = { r, g, b }
                     UnitFrames.CustomFramesApplyColours(true)
                 end,
                 width = "full",


### PR DESCRIPTION
Fixed a small oversight in setting up the Arcanist class specific strings, and fixed a typo that was the likely cause of grey group frames in BGs