### PR TITLE
code cleanup

### DIFF
--- a/Hooks.lua
+++ b/Hooks.lua
@@ -204,7 +204,7 @@ function LUIE.InitializeHooks()
 
         -- Hook support for Custom Ability Icons (Helps normalize with other addons)
         LUIE.GetAbilityIcon = GetAbilityIcon -- Used only for PTS testing
-        zos_GetAbilityIcon = GetAbilityIcon
+        local zos_GetAbilityIcon = GetAbilityIcon
         GetAbilityIcon = function(abilityId)
             local icon = zos_GetAbilityIcon(abilityId)
             if LUIE.Data.Effects.EffectOverride[abilityId] and LUIE.Data.Effects.EffectOverride[abilityId].icon then
@@ -215,7 +215,7 @@ function LUIE.InitializeHooks()
 
         -- Hook support for Custom Ability Names (Helps normalize with other addons)
         LUIE.GetAbilityName = GetAbilityName -- Used only for PTS testing
-        zos_GetAbilityName = GetAbilityName
+        local zos_GetAbilityName = GetAbilityName
         GetAbilityName = function(abilityId)
             local abilityName = zos_GetAbilityName(abilityId)
             if LUIE.Data.Effects.EffectOverride[abilityId] and LUIE.Data.Effects.EffectOverride[abilityId].name then
@@ -226,7 +226,7 @@ function LUIE.InitializeHooks()
 
         -- Hook support for ArtificialffectId's
         LUIE.GetArtificialEffectInfo = GetArtificialEffectInfo -- Used only for PTS testing
-        zos_GetArtificialEffectInfo = GetArtificialEffectInfo
+        local zos_GetArtificialEffectInfo = GetArtificialEffectInfo
         GetArtificialEffectInfo = function(artificialEffectId)
             local displayName, iconFile, effectType, sortOrder, timeStarted, timeEnding = zos_GetArtificialEffectInfo(artificialEffectId)
             if LUIE.Data.Effects.ArtificialEffectOverride[artificialEffectId] and LUIE.Data.Effects.ArtificialEffectOverride[artificialEffectId].icon then
@@ -239,7 +239,7 @@ function LUIE.InitializeHooks()
         end
 
         -- Hook support to pull custom tooltips for ArtificialEffectId's
-        zos_GetArtificialEffectTooltipText = GetArtificialEffectTooltipText
+        local zos_GetArtificialEffectTooltipText = GetArtificialEffectTooltipText
         GetArtificialEffectTooltipText = function(artificialEffectId)
             local tooltip
             if LUIE.Data.Effects.ArtificialEffectOverride[artificialEffectId] and LUIE.Data.Effects.ArtificialEffectOverride[artificialEffectId].tooltip then

--- a/Unlock.lua
+++ b/Unlock.lua
@@ -169,7 +169,7 @@ function LUIE.SetupElementMover(state)
             end)
             g_LUIE_Movers[tlw.customPositionAttr] = tlw
         end
-        tlw = g_LUIE_Movers[k:GetName()]
+        local tlw = g_LUIE_Movers[k:GetName()]
         tlw:SetMouseEnabled ( state )
         tlw:SetMovable ( state )
         tlw:SetHidden( not state )

--- a/data/Tooltips.lua
+++ b/data/Tooltips.lua
@@ -1530,6 +1530,7 @@ LUIE.Data.Tooltips = {
 
 -- Returns dynamic tooltips when called by Tooltip function
 function LUIE.DynamicTooltip(abilityId)
+    local tooltip = {}
     -- Brace
     if abilityId == 974 then
         local _, _, mitigation = GetAdvancedStatValue(ADVANCED_STAT_DISPLAY_TYPE_BLOCK_MITIGATION)

--- a/modules/CombatInfo/AbilityAlerts.lua
+++ b/modules/CombatInfo/AbilityAlerts.lua
@@ -225,10 +225,10 @@ function AbilityAlerts.CreateAlertFrame()
     uiTlw.alertFrame.preview.anchorLabel = UI.Label(uiTlw.alertFrame.preview, {BOTTOMLEFT,TOPLEFT,0,-1}, nil, {0,2}, "ZoFontGameSmall", "xxx, yyy", false)
     uiTlw.alertFrame.preview.anchorLabel:SetColor(1, 1, 0 , 1)
     uiTlw.alertFrame.preview.anchorLabel:SetDrawLayer(DL_OVERLAY)
-    uiTlw.alertFrame.preview.anchorLabel:SetDrawTier(1)
+    uiTlw.alertFrame.preview.anchorLabel:SetDrawTier(DT_MEDIUM)
     uiTlw.alertFrame.preview.anchorLabelBg = UI.Backdrop(uiTlw.alertFrame.preview.anchorLabel, "fill", nil, {0,0,0,1}, {0,0,0,1}, false)
     uiTlw.alertFrame.preview.anchorLabelBg:SetDrawLayer(DL_OVERLAY)
-    uiTlw.alertFrame.preview.anchorLabelBg:SetDrawTier(0)
+    uiTlw.alertFrame.preview.anchorLabelBg:SetDrawTier(DT_LOW)
 
     local fragment = ZO_HUDFadeSceneFragment:New(uiTlw.alertFrame, 0, 0)
 

--- a/modules/CombatInfo/CombatInfo.lua
+++ b/modules/CombatInfo/CombatInfo.lua
@@ -45,7 +45,7 @@ CombatInfo.Defaults = {
     ProcSoundName = "Death Recap Killing Blow",
     ShowToggled = true,
     ShowToggledUltimate = true,
-    BarShowLabel = false, -- Temp Disabled
+    BarShowLabel = true, -- Temp Disabled
     BarLabelPosition = -20,
     BarFontFace = "Univers 67",
     BarFontStyle = "outline",
@@ -415,9 +415,9 @@ function CombatInfo.Initialize(enabled)
     CombatInfo.Enabled = true
 
     -- TODO: TEMP: Disabled due to issues
-    if CombatInfo.SV.BarShowLabel == true then
-        CombatInfo.SV.BarShowLabel = false
-    end
+    -- if CombatInfo.SV.BarShowLabel == true then
+        -- CombatInfo.SV.BarShowLabel = false
+    -- end
 
     CombatInfo.ApplyFont()
     CombatInfo.ApplyProcSound()
@@ -1184,7 +1184,7 @@ function CombatInfo.ApplyProcSound(menu)
         barProcSound = "DeathRecap_KillingBlowShown"
     end
 
-    g_procSound = barProcSound
+    local g_procSound = barProcSound
 
     if menu then
         PlaySound(g_procSound)
@@ -1864,10 +1864,10 @@ function CombatInfo.CreateCastBar()
     uiTlw.castBar.preview.anchorLabel = UI.Label(uiTlw.castBar.preview, { BOTTOMLEFT, TOPLEFT, 0, -1 }, nil, { 0, 2 }, "ZoFontGameSmall", "xxx, yyy", false)
     uiTlw.castBar.preview.anchorLabel:SetColor(1, 1, 0, 1)
     uiTlw.castBar.preview.anchorLabel:SetDrawLayer(DL_OVERLAY)
-    uiTlw.castBar.preview.anchorLabel:SetDrawTier(1)
+    uiTlw.castBar.preview.anchorLabel:SetDrawTier(DT_MEDIUM)
     uiTlw.castBar.preview.anchorLabelBg = UI.Backdrop(uiTlw.castBar.preview.anchorLabel, "fill", nil, { 0, 0, 0, 1 }, { 0, 0, 0, 1 }, false)
     uiTlw.castBar.preview.anchorLabelBg:SetDrawLayer(DL_OVERLAY)
-    uiTlw.castBar.preview.anchorLabelBg:SetDrawTier(0)
+    uiTlw.castBar.preview.anchorLabelBg:SetDrawTier(DT_LOW)
 
     local fragment = ZO_HUDFadeSceneFragment:New(uiTlw.castBar, 0, 0)
 
@@ -2583,15 +2583,15 @@ function CombatInfo.PlayProcAnimations(slotNum)
         procLoopTexture:SetAnchor(BOTTOMRIGHT, actionButton.slot:GetNamedChild("FlipCard"))
         procLoopTexture:SetTexture("/esoui/art/actionbar/abilityhighlight_mage_med.dds")
         procLoopTexture:SetBlendMode(TEX_BLEND_MODE_ADD)
-        procLoopTexture:SetDrawLevel(2)
+        procLoopTexture:SetDrawLayer(DL_TEXT)
         procLoopTexture:SetHidden(true)
 
         procLoopTexture.label = UI.Label(procLoopTexture, nil, nil, nil, g_barFont, nil, false)
         procLoopTexture.label:SetAnchor(TOPLEFT, actionButton.slot)
         procLoopTexture.label:SetAnchor(BOTTOMRIGHT, actionButton.slot, nil, 0, -CombatInfo.SV.BarLabelPosition)
-        procLoopTexture.label:SetDrawLayer(DL_COUNT)
-        procLoopTexture.label:SetDrawLevel(3)
-        procLoopTexture.label:SetDrawTier(3)
+        procLoopTexture.label:SetDrawLayer(DL_CONTROLS)
+        procLoopTexture.label:SetDrawLayer(DL_OVERLAY)
+        procLoopTexture.label:SetDrawTier(DT_HIGH)
         procLoopTexture.label:SetColor(unpack(CombatInfo.SV.RemainingTextColoured and colour or { 1, 1, 1, 1 }))
         procLoopTexture.label:SetHidden(false)
 
@@ -2655,18 +2655,18 @@ function CombatInfo.ShowCustomToggle(slotNum)
             toggleFrame:SetAnchor(BOTTOMRIGHT, actionButton.slot:GetNamedChild("FlipCard"))
             toggleFrame:SetTexture("/esoui/art/actionbar/actionslot_toggledon.dds")
             toggleFrame:SetBlendMode(TEX_BLEND_MODE_ADD)
-            toggleFrame:SetDrawLayer(0)
+            toggleFrame:SetDrawLayer(DL_BACKGROUND)
             toggleFrame:SetDrawLevel(0)
-            toggleFrame:SetDrawTier(2)
+            toggleFrame:SetDrawTier(DT_HIGH)
             toggleFrame:SetColor(0.5, 1, 0.5, 1)
             toggleFrame:SetHidden(false)
 
             toggleFrame.label = UI.Label(toggleFrame, nil, nil, nil, g_barFont, nil, false)
             toggleFrame.label:SetAnchor(TOPLEFT, actionButton.slot)
             toggleFrame.label:SetAnchor(BOTTOMRIGHT, actionButton.slot, nil, 0, -CombatInfo.SV.BarLabelPosition)
-            toggleFrame.label:SetDrawLayer(DL_COUNT)
+            toggleFrame.label:SetDrawLayer(DL_CONTROLS)
             toggleFrame.label:SetDrawLevel(1)
-            toggleFrame.label:SetDrawTier(3)
+            toggleFrame.label:SetDrawTier(DT_HIGH)
             toggleFrame.label:SetColor(unpack(CombatInfo.SV.RemainingTextColoured and colour or { 1, 1, 1, 1 }))
             toggleFrame.label:SetHidden(false)
 
@@ -2676,9 +2676,9 @@ function CombatInfo.ShowCustomToggle(slotNum)
             --toggleFrame.stack:SetAnchor(TOPLEFT, actionButton.slot)
             --toggleFrame.stack:SetAnchor(BOTTOMRIGHT, actionButton.slot, nil, 22, -22)
 
-            toggleFrame.stack:SetDrawLayer(DL_COUNT)
+            toggleFrame.stack:SetDrawLayer(DL_CONTROLS)
             toggleFrame.stack:SetDrawLevel(1)
-            toggleFrame.stack:SetDrawTier(3)
+            toggleFrame.stack:SetDrawTier(DT_HIGH)
             toggleFrame.stack:SetColor(unpack(CombatInfo.SV.RemainingTextColoured and colour or { 1, 1, 1, 1 }))
             toggleFrame.stack:SetHidden(false)
 

--- a/modules/SlashCommands/Guild.lua
+++ b/modules/SlashCommands/Guild.lua
@@ -166,7 +166,7 @@ function SlashCommands.SlashGuildKick(option)
     local guildNumbers = GetNumGuildMembers(guildnumber)
     local compareChar = string.lower(name)
 
-    g_guildNamesTable = { }
+    local g_guildNamesTable = { }
 
     for i = 1,guildNumbers do
         local displayName = GetGuildMemberInfo(guildnumber, i)

--- a/modules/SpellCastBuffs/Debug.lua
+++ b/modules/SpellCastBuffs/Debug.lua
@@ -144,7 +144,7 @@ function SpellCastBuffs.AuthorCombatDebug(eventCode, result, isError, abilityNam
     local formattedResult = LUIE.Data.DebugResults[result]
 
     if Effects.EffectOverride[abilityId] and Effects.EffectOverride[abilityId].hide then
-        finalString = (iconFormatted .. "[" ..abilityId .. "] " .. nameFormatted.. ": HIDDEN LUI" .. cmxHIDE .. ": [S] "..source.." --> [T] "..target .. " [R] " .. formattedResult)
+        local finalString = (iconFormatted .. "[" ..abilityId .. "] " .. nameFormatted.. ": HIDDEN LUI" .. cmxHIDE .. ": [S] "..source.." --> [T] "..target .. " [R] " .. formattedResult)
         finalString = MillisecondTimestampDebug(finalString)
         if CHAT_SYSTEM.primaryContainer then
             for k, cc in ipairs(CHAT_SYSTEM.containers) do

--- a/modules/SpellCastBuffs/SpellCastBuffs.lua
+++ b/modules/SpellCastBuffs/SpellCastBuffs.lua
@@ -2330,6 +2330,7 @@ function SpellCastBuffs.OnCombatEventIn(eventCode, result, isError, abilityName,
             return
         end
 
+        local stack = {}
         local iconName = GetAbilityIcon(abilityId)
         local effectName
         local unbreakable
@@ -2522,7 +2523,7 @@ function SpellCastBuffs.OnCombatEventIn(eventCode, result, isError, abilityName,
         effectName = Effects.FakeExternalBuffs[abilityId].name or GetAbilityName(abilityId)
         local context = SpellCastBuffs.DetermineContextSimple("player1", abilityId, effectName)
         SpellCastBuffs.EffectsList[context][abilityId] = nil
-        overrideDuration = Effects.FakeExternalBuffs[abilityId].overrideDuration
+        local overrideDuration = Effects.FakeExternalBuffs[abilityId].overrideDuration
         duration = Effects.FakeExternalBuffs[abilityId].duration
         local beginTime = GetGameTimeMilliseconds()
         local endTime = beginTime + duration
@@ -2933,7 +2934,7 @@ function SpellCastBuffs.OnCombatEventOut(eventCode, result, isError, abilityName
         effectName = Effects.FakePlayerDebuffs[abilityId].name or GetAbilityName(abilityId)
         local context = "reticleover2" -- NOTE: TODO - No prominent support here and probably won't add
         duration = Effects.FakePlayerDebuffs[abilityId].duration
-        overrideDuration = Effects.FakePlayerDebuffs[abilityId].overrideDuration
+        local overrideDuration = Effects.FakePlayerDebuffs[abilityId].overrideDuration
         effectType = BUFF_EFFECT_TYPE_DEBUFF
         local beginTime = GetGameTimeMilliseconds()
         local endTime = beginTime + duration
@@ -3218,7 +3219,7 @@ function SpellCastBuffs.AddNameAura()
                 return
             end
 
-            stack = v.stack or 0
+            local stack = v.stack or 0
 
             local zone = v.zone
             if zone then

--- a/modules/SpellCastBuffs/Werewolf.lua
+++ b/modules/SpellCastBuffs/Werewolf.lua
@@ -45,7 +45,7 @@ end
 function SpellCastBuffs.WerewolfState(eventCode, werewolf, onActivation)
     if werewolf and not SpellCastBuffs.SV.HidePlayerBuffs then
         for i = 1, 6 do
-            name, _, discovered, skillLineId = GetSkillLineInfo(SKILL_TYPE_WORLD, i)
+            local name, _, discovered, skillLineId = GetSkillLineInfo(SKILL_TYPE_WORLD, i)
             if skillLineId == 50 and discovered then
                 g_werewolfCounter = g_werewolfCounter + 1
                 if g_werewolfCounter == 3 or onActivation then

--- a/modules/UnitFrames/UnitFrames.lua
+++ b/modules/UnitFrames/UnitFrames.lua
@@ -1146,10 +1146,10 @@ local function CreateCustomFrames()
             unitFrame.tlw.preview.anchorLabel = UI.Label( unitFrame.tlw.preview, {BOTTOMLEFT,TOPLEFT,0,-1}, nil, {0,2}, "ZoFontGameSmall", "xxx, yyy", false )
             unitFrame.tlw.preview.anchorLabel:SetColor(1, 1, 0 , 1)
             unitFrame.tlw.preview.anchorLabel:SetDrawLayer(DL_OVERLAY)
-            unitFrame.tlw.preview.anchorLabel:SetDrawTier(1)
+            unitFrame.tlw.preview.anchorLabel:SetDrawTier(DT_MEDIUM)
             unitFrame.tlw.preview.anchorLabelBg = UI.Backdrop( unitFrame.tlw.preview.anchorLabel, "fill", nil, {0,0,0,1}, {0,0,0,1}, false )
             unitFrame.tlw.preview.anchorLabelBg:SetDrawLayer(DL_OVERLAY)
-            unitFrame.tlw.preview.anchorLabelBg:SetDrawTier(0)
+            unitFrame.tlw.preview.anchorLabelBg:SetDrawTier(DT_LOW)
         end
 
         -- Now we have to anchor all bars to their backdrops
@@ -1361,6 +1361,7 @@ local function CreateCustomFrames()
     if UnitFrames.SV.PlayerEnablePower then
         for _, baseName in pairs( { 'player', 'reticleover', 'AvaPlayerTarget' } ) do
             local unitTag = baseName
+            local size1, size2
             if UnitFrames.CustomFrames[unitTag] then
                 if baseName == "player" then
                     size1 = UnitFrames.SV.PlayerBarWidth
@@ -3473,7 +3474,7 @@ function UnitFrames.CustomFramesSetDeadLabel( unitFrame, newValue )
         unitFrame.dead:SetText( newValue )
     end
     if newValue == "Offline" then
-        classIcon = classIcons[0]
+        local classIcon = classIcons[0]
         if unitFrame.level ~= nil then
             unitFrame.level:SetHidden( newValue ~= "Dead" or newValue ~= nil )
         end
@@ -4983,7 +4984,14 @@ function UnitFrames.CustomFramesApplyLayoutRaid(unhide)
 
     -- Create a list of players and insert the players according to their role
     local playerList = {}
-    table.foreach({ LFG_ROLE_TANK, LFG_ROLE_HEAL, LFG_ROLE_DPS, LFG_ROLE_INVALID }, function(_, value) insertRole(playerList, value) end)
+
+    -- depreciated table function
+    -- table.foreach({ LFG_ROLE_TANK, LFG_ROLE_HEAL, LFG_ROLE_DPS, LFG_ROLE_INVALID }, function(_, value) insertRole(playerList, value) end)
+    
+    local roles = { LFG_ROLE_TANK, LFG_ROLE_HEAL, LFG_ROLE_DPS, LFG_ROLE_INVALID }
+    for _, value in ipairs(roles) do
+        insertRole(playerList, value)
+    end
 
     local column = 0    -- 0,1,2,3,4,5
     local row = 0       -- 1,2,3,...,12

--- a/settings/CombatInfo.lua
+++ b/settings/CombatInfo.lua
@@ -361,8 +361,8 @@ function CombatInfo.CreateSettings()
                 setFunc = function(value) Settings.BarShowLabel = value CombatInfo.ResetBarLabel() end,
                 width = "full",
                 default = Defaults.BarShowLabel,
-                --disabled = function() return not ( LUIE.SV.CombatInfo_Enabled and ( Settings.ShowTriggered or Settings.ShowToggled) ) end,
-                disabled = true
+                disabled = function() return not ( LUIE.SV.CombatInfo_Enabled and ( Settings.ShowTriggered or Settings.ShowToggled) ) end,
+                --disabled = true
             },
             {
                 type = "slider",


### PR DESCRIPTION
# Changelog

## Updated modules\UnitFrames\UnitFrames.lua
- Depreciated table function replaced with a ipairs iterator.
- Adjusted numerous DrawTier and DrawLevel errors which fixed the action bar timers being usable again ironically.

## Updated UI.lua, Unlock.lua, modules\CombatInfo\AbilityAlerts.lua, modules\CombatInfo\CombatInfo.lua, modules\InfoPanel\InfoPanel.lua, modules\SpellCastBuffs\SpellCastBuffs.lua, modules\UnitFrames\UnitFrames.lua, settings\CombatInfo.lua
- Fixed some globals that should have been local. 

### Details:
- Hooks.lua:  `zos_GetAbilityIcon`  at line 207,  `zos_GetAbilityName`  at line 218,  `zos_GetArtificialEffectInfo`  at line 229,  `zos_GetArtificialEffectTooltipText`  at line 242.
- Unlock.lua:  `tlw`  at line 172
- data/Tooltips.lua:  `tooltip`  at lines 1560, 1567, 1570, 1578, 1593, 1610, 1628.
- modules/CombatInfo/CombatInfo.lua:  `g_procSound`  at line 1187
- modules/SpellCastBuffs/SpellCastBuffs.lua:  `stack`  at lines 2345, 2349, 2434, 2436, 2439, 3221,  `overrideDuration`  at lines 2525, 2936.
- modules/SpellCastBuffs/Debug.lua:  `finalString`  at lines 147, 148
- modules/SpellCastBuffs/Werewolf.lua:  `_`  at line 48,  `discovered`  at line 48,  `name`  at line 48,  `skillLineId`  at line 48
- modules/SlashCommands/Guild.lua:  `g_guildNamesTable`  at line 169
- modules/UnitFrames/UnitFrames.lua:  `size1`  at lines 1366, 1369, 1372,  `size2`  at lines 1367, 1370, 1373,  `classIcon`  at line 3476.