### PR TITLE
Update CC Tracker Ignore List for Endless Archive Transports

### DIFF
--- a/data/CrowdControl.lua
+++ b/data/CrowdControl.lua
@@ -724,6 +724,12 @@ CrowdControl.IgnoreList = {
     -- Dreadsail Reef
     [166794] = true, -- Raging Current -- Dreadsail Reef
 
+    -- Endless Archive
+    [192972] = true, -- Enter the Endless
+    [203125] = true, --- Verse Select
+    [203101] = true, -- Vision Select
+    [211431] = true, -- Side Content Transporter
+    
     ----------------
     -- Miscelaneous
     ----------------

--- a/data/CrowdControl.lua
+++ b/data/CrowdControl.lua
@@ -726,10 +726,11 @@ CrowdControl.IgnoreList = {
 
     -- Endless Archive
     [192972] = true, -- Enter the Endless
+    [194571] = true, -- Enter the Endless
     [203125] = true, --- Verse Select
     [203101] = true, -- Vision Select
     [211431] = true, -- Side Content Transporter
-    
+
     ----------------
     -- Miscelaneous
     ----------------


### PR DESCRIPTION
When moving through the Endless Archive several effects are popping in the CC tracker that are unnecessary such as; the portal at the end of each stage, the portal to side content, interacting with Verse or Vision selection pools.
This will silence these, preventing their alert audio and appearance in the CC tracker.