### PR TITLE
Update Ignore List for Endless Archive

### DIFF
--- a/data/CrowdControl.lua
+++ b/data/CrowdControl.lua
@@ -724,6 +724,13 @@ CrowdControl.IgnoreList = {
     -- Dreadsail Reef
     [166794] = true, -- Raging Current -- Dreadsail Reef
 
+    -- Endless Archive
+    [192972] = true, -- Enter the Endless
+    [194571] = true, -- Enter the Endless
+    [203125] = true, --- Verse Select
+    [203101] = true, -- Vision Select
+    [211431] = true, -- Side Content Transporter
+
     ----------------
     -- Miscelaneous
     ----------------

--- a/data/CrowdControl.lua
+++ b/data/CrowdControl.lua
@@ -729,7 +729,7 @@ CrowdControl.IgnoreList = {
     [194570] = true, -- Enter the Endless
     [192972] = true, -- Enter the Endless
     [194571] = true, -- Enter the Endless
-    [203125] = true, --- Verse Select
+    [203125] = true, -- Verse Select
     [203101] = true, -- Vision Select
     [211431] = true, -- Side Content Transporter
 

--- a/data/CrowdControl.lua
+++ b/data/CrowdControl.lua
@@ -725,6 +725,8 @@ CrowdControl.IgnoreList = {
     [166794] = true, -- Raging Current -- Dreadsail Reef
 
     -- Endless Archive
+    [192956] = true, -- Enter the Endless
+    [194570] = true, -- Enter the Endless
     [192972] = true, -- Enter the Endless
     [194571] = true, -- Enter the Endless
     [203125] = true, --- Verse Select


### PR DESCRIPTION
Reopened PR on develop per request.

> When moving through the Endless Archive several effects are popping in the CC tracker that are unnecessary such as; the portal at the end of each stage, the portal to side content, interacting with Verse or Vision selection pools.
This will silence these, preventing their alert audio and appearance in the CC tracker.

