### PR TITLE
Add Goat Transformation in Endless Archive

### DIFF
--- a/data/CrowdControl.lua
+++ b/data/CrowdControl.lua
@@ -732,6 +732,7 @@ CrowdControl.IgnoreList = {
     [203125] = true, -- Verse Select
     [203101] = true, -- Vision Select
     [211431] = true, -- Side Content Transporter
+    [192506] = true, -- Unstable Metamorphosis
 
     ----------------
     -- Miscelaneous

--- a/data/CrowdControl.lua
+++ b/data/CrowdControl.lua
@@ -733,6 +733,7 @@ CrowdControl.IgnoreList = {
     [203125] = true, -- Verse Select
     [203101] = true, -- Vision Select
     [211431] = true, -- Side Content Transporter
+    [211433] = true, -- Side Content Selector (Group)
     [192506] = true, -- Unstable Metamorphosis
 
     ----------------

--- a/data/CrowdControl.lua
+++ b/data/CrowdControl.lua
@@ -729,6 +729,7 @@ CrowdControl.IgnoreList = {
     [194570] = true, -- Enter the Endless
     [192972] = true, -- Enter the Endless
     [194571] = true, -- Enter the Endless
+    [202803] = true, -- Enter the Endless (Group)
     [203125] = true, -- Verse Select
     [203101] = true, -- Vision Select
     [211431] = true, -- Side Content Transporter


### PR DESCRIPTION
Missed one. In the side content when you're turned into a goat to chase sweetrolls, the transformation is poping as a CC. This adds that to the ignore list.