### PR TITLE
More Reliable Negate Behavior Fix

### DIFF
--- a/modules/CombatInfo/CrowdControlTracker.lua
+++ b/modules/CombatInfo/CrowdControlTracker.lua
@@ -41,6 +41,8 @@ local ICON_MISSING = "icon_missing"
 
 local ACTION_RESULT_AREA_EFFECT = 669966
 
+local NEGATE_MAGIC_ID = 47158
+local NEGATE_MAGIC_1_ID = 51894
 local negateValidNames = {
     ["Negate Magic"] = true,
     ["Absorption Field"] = true,
@@ -62,7 +64,6 @@ CrowdControlTracker.controlTypes = {
 CrowdControlTracker.actionResults = {
     [ACTION_RESULT_STUNNED] = true,
     [ACTION_RESULT_DISORIENTED] = true,
-    [ACTION_RESULT_SILENCED] = true,
     [ACTION_RESULT_FEARED] = true,
     [ACTION_RESULT_CHARMED] = true,
     [ACTION_RESULT_ROOTED] = true,
@@ -469,7 +470,6 @@ function CrowdControlTracker:OnCombat(eventCode, result, isError, abilityName, a
         [ACTION_RESULT_CHARMED] = true,
         [ACTION_RESULT_ROOTED] = true,
         [ACTION_RESULT_SNARED] = true,
-        [ACTION_RESULT_SILENCED] = true,
     }
 
     if not validResults[result] then
@@ -508,8 +508,7 @@ function CrowdControlTracker:OnCombat(eventCode, result, isError, abilityName, a
     end
 
     if result == ACTION_RESULT_EFFECT_GAINED_DURATION then
-        if abilityId == self.incomingCC[ACTION_RESULT_SILENCED] then
-            if not negateValidNames[abilityName] then return end
+        if abilityName == GetAbilityName(NEGATE_MAGIC_ID) or abilityId == NEGATE_MAGIC_ID or abilityId == NEGATE_MAGIC_1_ID or negateValidNames[abilityName] then
             if hitValue < negateDuration then hitValue = negateDuration end
             local currentEndTimeSilence = GetFrameTimeMilliseconds() + hitValue
             table_insert(self.negatesQueue, abilityId)

--- a/modules/CombatInfo/CrowdControlTracker.lua
+++ b/modules/CombatInfo/CrowdControlTracker.lua
@@ -467,6 +467,7 @@ function CrowdControlTracker:OnCombat(eventCode, result, isError, abilityName, a
         [ACTION_RESULT_CHARMED] = true,
         [ACTION_RESULT_ROOTED] = true,
         [ACTION_RESULT_SNARED] = true,
+        [ACTION_RESULT_SILENCED] = true,
     }
 
     if not validResults[result] then

--- a/modules/CombatInfo/CrowdControlTracker.lua
+++ b/modules/CombatInfo/CrowdControlTracker.lua
@@ -40,9 +40,6 @@ local GENERIC_ROOT_ABILITY_ID = 146956
 local ICON_MISSING = "icon_missing"
 
 local ACTION_RESULT_AREA_EFFECT = 669966
-
-local NEGATE_MAGIC_ID = 47158
-local NEGATE_MAGIC_1_ID = 51894
 local negateValidNames = {
     ["Negate Magic"] = true,
     ["Absorption Field"] = true,
@@ -508,7 +505,7 @@ function CrowdControlTracker:OnCombat(eventCode, result, isError, abilityName, a
     end
 
     if result == ACTION_RESULT_EFFECT_GAINED_DURATION then
-        if abilityName == GetAbilityName(NEGATE_MAGIC_ID) or abilityId == NEGATE_MAGIC_ID or abilityId == NEGATE_MAGIC_1_ID or negateValidNames[abilityName] then
+        if negateValidNames[GetAbilityName(abilityId)] then
             if hitValue < negateDuration then hitValue = negateDuration end
             local currentEndTimeSilence = GetFrameTimeMilliseconds() + hitValue
             table_insert(self.negatesQueue, abilityId)


### PR DESCRIPTION
Partial revert of the detection method for negates that I used in the previous fix that was apparently causing the bug I observed. This version should still fix the issues I'd identified with the previous implementation of the negate tracker, but, like the original version, doesn't depend on the apparently unreliable ACTION_RESULT_SILENCED.