### PR TITLE
Add Drinweth armorer to collectible table

### DIFF
--- a/data/CollectibleTables.lua
+++ b/data/CollectibleTables.lua
@@ -29,6 +29,7 @@ local CollectibleTables =
     Armory = {
         [9745] = "Ghrasharog",
         [10618] = "Zhuqoth",
+        [11876] = "Drinweth",
     },
 
     -- Deconstruction


### PR DESCRIPTION
The change adds support for the armory `Drinweth, Valenwood Armorer`. It is currently not recognized by the addon, so the slash command and key binding for it don't work.