### PR TITLE
Added Warden AOE pre-Charm AoE to AoE alerts

### DIFF
--- a/data/CrowdControl.lua
+++ b/data/CrowdControl.lua
@@ -90,9 +90,11 @@ CrowdControl.aoePlayerNormal = {
     [32711] = 1, -- Eruption (Eruption)
 
     -- Warden
-    [220639] = 1, -- Warden's Burst (Warden Scribing Class Charm Initial Cast)
-    [220630] = 0, -- Warden's Burst (Warden Scribing Class Charm Initial Cast)
-    [220629] = 0, -- Warden's Burst (Warden Scribing Class Charm Initial Cast)
+    [220630] = 1, -- Warden's Burst (Warden Scribing Class Charm Initial Cast)
+    [220639] = 0, -- Warden's Burst (Warden Scribing Class Charm Initial Cast)
+
+    [221173] = 1, -- Warden's Contingency (Warden Scribing Class Charm Initial Cast)
+    [221174] = 0, -- Warden's Contingency (Warden Scribing Class Charm Initial Cast)
 
     --[130406] = 0, -- Arctic Blast (Arctic Blast)
     [88783] = 1, -- Impaling Shards (Impaling Shards)

--- a/data/CrowdControl.lua
+++ b/data/CrowdControl.lua
@@ -90,6 +90,10 @@ CrowdControl.aoePlayerNormal = {
     [32711] = 1, -- Eruption (Eruption)
 
     -- Warden
+    [220639] = 1, -- Warden's Burst (Warden Scribing Class Charm Initial Cast)
+    [220630] = 0, -- Warden's Burst (Warden Scribing Class Charm Initial Cast)
+    [220629] = 0, -- Warden's Burst (Warden Scribing Class Charm Initial Cast)
+
     --[130406] = 0, -- Arctic Blast (Arctic Blast)
     [88783] = 1, -- Impaling Shards (Impaling Shards)
     [88791] = 0, -- Gripping Shards (Gripping Shards)


### PR DESCRIPTION
The Warden Scribing Class Script is a big AOE charm. Currently LUI's CC tracker warns you when you actually start moving as a result of the charm effect, but not when you're standing in the AOE that will cause you to get charmed in the first place. This change allows the AOE portion of the CC tracker to alert you when you are in this AOE.
This is important because the enemy telegraph for the effect is currently not behaving as intended and is frequently failing to render.