### PR TITLE
Fix ExecutePercentage=0 being ignored on unit frames

### DIFF
--- a/LuiExtended/modules/UnitFrames/UnitFrames.lua
+++ b/LuiExtended/modules/UnitFrames/UnitFrames.lua
@@ -191,6 +191,7 @@ function UnitFrames.Initialize(enabled)
 
     UnitFrames.CreateDefaultFrames()
     UnitFrames.CreateCustomFrames()
+    UnitFrames.CustomFramesReloadExecuteMenu()
 
     function BOSS_BAR:RefreshBossHealthBar(smoothAnimate)
         local totalHealth = 0

--- a/LuiExtended/modules/UnitFrames/_UnitAttributeVisuals.lua
+++ b/LuiExtended/modules/UnitFrames/_UnitAttributeVisuals.lua
@@ -153,8 +153,8 @@ function UnitFrames.UpdateAttribute(unitTag, powerType, attributeFrame, powerVal
                 attributeFrame[label]:SetColor(unpack(attributeFrame.color or { 1, 1, 1, 1 }))
             else
                 -- And color it RED if attribute value is lower than the threshold
-                attributeFrame[label]:SetColor(unpack((pct < (attributeFrame.threshold or UnitFrames.defaultThreshold)) and { 1, 0.25, 0.38, 1 } or attributeFrame.color or { 1, 1, 1, 1 }))
-            end
+                local threshold = (attributeFrame.threshold ~= nil) and attributeFrame.threshold or UnitFrames.defaultThreshold
+                attributeFrame[label]:SetColor(unpack((pct < threshold) and { 1, 0.25, 0.38, 1 } or attributeFrame.color or { 1, 1, 1, 1 }))            end
         end
     end
 


### PR DESCRIPTION
When users set `ExecutePercentage` to 0 to disable red health text coloring, the setting gets ignored and falls back to using the default threshold due to two issues:

### Issue 1: Lua truthiness bug

The 0 gets treated as falsy, so when `attributeFrame.threshold` is 0, it falls back to `g_defaultThreshold`:

```lua
else
    -- And color it RED if attribute value is lower than the threshold
    attributeFrame[label]:SetColor(unpack((pct < (attributeFrame.threshold or g_defaultThreshold)) and { 1, 0.25, 0.38 } or attributeFrame.color or { 1, 1, 1 }))
end
```

This splits it into two lines with an explicit nil check so that it always uses the user setting even if it's 0:

```lua
local threshold = (attributeFrame.threshold ~= nil) and attributeFrame.threshold or g_defaultThreshold
attributeFrame[label]:SetColor(unpack((pct < threshold) and { 1, 0.25, 0.38 } or attributeFrame.color or { 1, 1, 1 }))
```

### Issue 2: Applying settings during initialization

User settings don't actually get applied to the frames properly without calling `UnitFrames.CustomFramesReloadExecuteMenu()` during initialization:

```lua
UnitFrames.CreateDefaultFrames()
UnitFrames.CreateCustomFrames()

-- Update frame thresholds with user settings
UnitFrames.CustomFramesReloadExecuteMenu()
```

Only after both changes does it correctly recognize the setting of 0 and no longer turn enemy health text red when below the threshold value.