### PR TITLE
Synergy fix

### DIFF
--- a/LuiExtended/console/Initialize_Console.lua
+++ b/LuiExtended/console/Initialize_Console.lua
@@ -43,7 +43,6 @@ eventManager:RegisterForEvent(LUIE.name, EVENT_ADD_ON_LOADED, function (eventId,
         -- Initialize Hooks
         LUIE.API_Hooks()
         LUIE.HookActionButton()
-        LUIE.HookSynergy()
         LUIE.InitializeHooksSkillAdvisor()
         LUIE.HookGamePadIcons()
         LUIE.HookGamePadStats()

--- a/LuiExtended/frontend/SynergyTracker.xml
+++ b/LuiExtended/frontend/SynergyTracker.xml
@@ -4,946 +4,117 @@
 -->
 <GuiXml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/DakJaniels/esoui_gui_xsd/main/esoui_gui_xml.xsd">
-        <Controls>
-                <TopLevelControl name="LUIE_SynergyTracker_UI"
-                                 mouseEnabled="false"
-                                 movable="false"
-                                 clampedToScreen="true"
-                                 hidden="true"
-                                 layer="0"
-                                 level="1"
-                                 tier="1">
-                        <Dimensions x="320"
-                                    y="440" />
-                        <Anchor point="CENTER"
-                                relativeTo="GuiRoot"
-                                relativePoint="CENTER"
-                                offsetX="0"
-                                offsetY="200" />
-                        <OnMoveStop>
-        LUIE.CombatInfo.SynergyTracker.OnMoveStop()
-      </OnMoveStop>
-                        <OnUpdate>
-        LUIE.CombatInfo.SynergyTracker.OnUpdate(self)
-      </OnUpdate>
-                        <Controls>
-                                <!-- Background for unlock mode -->
-                                <Backdrop name="$(parent)_Background"
-                                          hidden="true"
-                                          centerColor="00000080"
-                                          edgeColor="4D4D4DCC">
-                                        <AnchorFill />
-                                </Backdrop>
-                                <!-- Synergy Rows (10 slots) -->
-                                <Control name="$(parent)_Row1"
-                                         mouseEnabled="true"
-                                         hidden="true">
-                                        <Dimensions x="320"
-                                                    y="44" />
-                                        <Anchor point="TOP"
-                                                relativeTo="$(parent)"
-                                                relativePoint="TOP"
-                                                offsetX="0"
-                                                offsetY="0" />
-                                        <Controls>
-                                                <!-- Icon Background -->
-                                                <Texture name="$(parent)_IconBg"
-                                                         textureFile="EsoUI/Art/ActionBar/abilityFrame64_up.dds">
-                                                        <Dimensions x="40"
-                                                                    y="40" />
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="LEFT"
-                                                                offsetX="2"
-                                                                offsetY="0" />
-                                                </Texture>
-                                                <!-- Icon -->
-                                                <Texture name="$(parent)_Icon">
-                                                        <Dimensions x="36"
-                                                                    y="36" />
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Texture>
-                                                <!-- Position Number -->
-                                                <Label name="$(parent)_PosNum"
-                                                       font="ZoFontGamepad27"
-                                                       color="FFFF80"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       text="1"
-                                                       hidden="true">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <!-- Synergy Name -->
-                                                <Label name="$(parent)_Name"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       wrapMode="ELLIPSIS">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_PosNum"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="8"
-                                                                offsetY="0" />
-                                                        <DimensionConstraints minX="0"
-                                                                              minY="0"
-                                                                              maxX="200"
-                                                                              maxY="44" />
-                                                </Label>
-                                                <!-- Priority Indicator -->
-                                                <Label name="$(parent)_Priority"
-                                                       horizontalAlignment="RIGHT"
-                                                       verticalAlignment="CENTER"
-                                                       color="B3B3B3"
-                                                       hidden="true">
-                                                        <Anchor point="RIGHT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="-5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <!-- Cooldown Overlay -->
-                                                <Cooldown name="$(parent)_Cooldown"
-                                                          hidden="true"
-                                                          textureFile="EsoUI/Art/ActionBar/abilityHighlight.dds"
-                                                          fillColor="000000B3"
-                                                          desaturation="1">
-                                                        <Anchor point="TOPLEFT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="TOPLEFT" />
-                                                        <Anchor point="BOTTOMRIGHT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="BOTTOMRIGHT" />
-                                                </Cooldown>
-                                                <!-- Cooldown Text -->
-                                                <Label name="$(parent)_CooldownText"
-                                                       horizontalAlignment="CENTER"
-                                                       verticalAlignment="CENTER"
-                                                       color="FFFFFF"
-                                                       hidden="true">
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Label>
-                                        </Controls>
-                                </Control>
-                                <Control name="$(parent)_Row2"
-                                         mouseEnabled="true"
-                                         hidden="true">
-                                        <Dimensions x="320"
-                                                    y="44" />
-                                        <Anchor point="TOP"
-                                                relativeTo="$(parent)_Row1"
-                                                relativePoint="BOTTOM" />
-                                        <Controls>
-                                                <Texture name="$(parent)_IconBg"
-                                                         textureFile="EsoUI/Art/ActionBar/abilityFrame64_up.dds">
-                                                        <Dimensions x="40"
-                                                                    y="40" />
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="LEFT"
-                                                                offsetX="2"
-                                                                offsetY="0" />
-                                                </Texture>
-                                                <Texture name="$(parent)_Icon">
-                                                        <Dimensions x="36"
-                                                                    y="36" />
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Texture>
-                                                <Label name="$(parent)_PosNum"
-                                                       font="ZoFontGamepad27"
-                                                       color="FFFF80"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       text="2"
-                                                       hidden="true">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Label name="$(parent)_Name"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       wrapMode="ELLIPSIS">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_PosNum"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="8"
-                                                                offsetY="0" />
-                                                        <DimensionConstraints minX="0"
-                                                                              minY="0"
-                                                                              maxX="200"
-                                                                              maxY="44" />
-                                                </Label>
-                                                <Label name="$(parent)_Priority"
-                                                       horizontalAlignment="RIGHT"
-                                                       verticalAlignment="CENTER"
-                                                       color="B3B3B3"
-                                                       hidden="true">
-                                                        <Anchor point="RIGHT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="-5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Cooldown name="$(parent)_Cooldown"
-                                                          hidden="true"
-                                                          textureFile="EsoUI/Art/ActionBar/abilityHighlight.dds"
-                                                          fillColor="000000B3"
-                                                          desaturation="1">
-                                                        <Anchor point="TOPLEFT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="TOPLEFT" />
-                                                        <Anchor point="BOTTOMRIGHT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="BOTTOMRIGHT" />
-                                                </Cooldown>
-                                                <Label name="$(parent)_CooldownText"
-                                                       horizontalAlignment="CENTER"
-                                                       verticalAlignment="CENTER"
-                                                       color="FFFFFF"
-                                                       hidden="true">
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Label>
-                                        </Controls>
-                                </Control>
-                                <Control name="$(parent)_Row3"
-                                         mouseEnabled="true"
-                                         hidden="true">
-                                        <Dimensions x="320"
-                                                    y="44" />
-                                        <Anchor point="TOP"
-                                                relativeTo="$(parent)_Row2"
-                                                relativePoint="BOTTOM" />
-                                        <Controls>
-                                                <Texture name="$(parent)_IconBg"
-                                                         textureFile="EsoUI/Art/ActionBar/abilityFrame64_up.dds">
-                                                        <Dimensions x="40"
-                                                                    y="40" />
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="LEFT"
-                                                                offsetX="2"
-                                                                offsetY="0" />
-                                                </Texture>
-                                                <Texture name="$(parent)_Icon">
-                                                        <Dimensions x="36"
-                                                                    y="36" />
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Texture>
-                                                <Label name="$(parent)_PosNum"
-                                                       font="ZoFontGamepad27"
-                                                       color="FFFF80"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       text="3"
-                                                       hidden="true">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Label name="$(parent)_Name"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       wrapMode="ELLIPSIS">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_PosNum"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="8"
-                                                                offsetY="0" />
-                                                        <DimensionConstraints minX="0"
-                                                                              minY="0"
-                                                                              maxX="200"
-                                                                              maxY="44" />
-                                                </Label>
-                                                <Label name="$(parent)_Priority"
-                                                       horizontalAlignment="RIGHT"
-                                                       verticalAlignment="CENTER"
-                                                       color="B3B3B3"
-                                                       hidden="true">
-                                                        <Anchor point="RIGHT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="-5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Cooldown name="$(parent)_Cooldown"
-                                                          hidden="true"
-                                                          textureFile="EsoUI/Art/ActionBar/abilityHighlight.dds"
-                                                          fillColor="000000B3"
-                                                          desaturation="1">
-                                                        <Anchor point="TOPLEFT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="TOPLEFT" />
-                                                        <Anchor point="BOTTOMRIGHT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="BOTTOMRIGHT" />
-                                                </Cooldown>
-                                                <Label name="$(parent)_CooldownText"
-                                                       horizontalAlignment="CENTER"
-                                                       verticalAlignment="CENTER"
-                                                       color="FFFFFF"
-                                                       hidden="true">
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Label>
-                                        </Controls>
-                                </Control>
-                                <Control name="$(parent)_Row4"
-                                         mouseEnabled="true"
-                                         hidden="true">
-                                        <Dimensions x="320"
-                                                    y="44" />
-                                        <Anchor point="TOP"
-                                                relativeTo="$(parent)_Row3"
-                                                relativePoint="BOTTOM" />
-                                        <Controls>
-                                                <Texture name="$(parent)_IconBg"
-                                                         textureFile="EsoUI/Art/ActionBar/abilityFrame64_up.dds">
-                                                        <Dimensions x="40"
-                                                                    y="40" />
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="LEFT"
-                                                                offsetX="2"
-                                                                offsetY="0" />
-                                                </Texture>
-                                                <Texture name="$(parent)_Icon">
-                                                        <Dimensions x="36"
-                                                                    y="36" />
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Texture>
-                                                <Label name="$(parent)_PosNum"
-                                                       font="ZoFontGamepad27"
-                                                       color="FFFF80"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       text="4"
-                                                       hidden="true">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Label name="$(parent)_Name"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       wrapMode="ELLIPSIS">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_PosNum"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="8"
-                                                                offsetY="0" />
-                                                        <DimensionConstraints minX="0"
-                                                                              minY="0"
-                                                                              maxX="200"
-                                                                              maxY="44" />
-                                                </Label>
-                                                <Label name="$(parent)_Priority"
-                                                       horizontalAlignment="RIGHT"
-                                                       verticalAlignment="CENTER"
-                                                       color="B3B3B3"
-                                                       hidden="true">
-                                                        <Anchor point="RIGHT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="-5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Cooldown name="$(parent)_Cooldown"
-                                                          hidden="true"
-                                                          textureFile="EsoUI/Art/ActionBar/abilityHighlight.dds"
-                                                          fillColor="000000B3"
-                                                          desaturation="1">
-                                                        <Anchor point="TOPLEFT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="TOPLEFT" />
-                                                        <Anchor point="BOTTOMRIGHT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="BOTTOMRIGHT" />
-                                                </Cooldown>
-                                                <Label name="$(parent)_CooldownText"
-                                                       horizontalAlignment="CENTER"
-                                                       verticalAlignment="CENTER"
-                                                       color="FFFFFF"
-                                                       hidden="true">
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Label>
-                                        </Controls>
-                                </Control>
-                                <Control name="$(parent)_Row5"
-                                         mouseEnabled="true"
-                                         hidden="true">
-                                        <Dimensions x="320"
-                                                    y="44" />
-                                        <Anchor point="TOP"
-                                                relativeTo="$(parent)_Row4"
-                                                relativePoint="BOTTOM" />
-                                        <Controls>
-                                                <Texture name="$(parent)_IconBg"
-                                                         textureFile="EsoUI/Art/ActionBar/abilityFrame64_up.dds">
-                                                        <Dimensions x="40"
-                                                                    y="40" />
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="LEFT"
-                                                                offsetX="2"
-                                                                offsetY="0" />
-                                                </Texture>
-                                                <Texture name="$(parent)_Icon">
-                                                        <Dimensions x="36"
-                                                                    y="36" />
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Texture>
-                                                <Label name="$(parent)_PosNum"
-                                                       font="ZoFontGamepad27"
-                                                       color="FFFF80"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       text="5"
-                                                       hidden="true">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Label name="$(parent)_Name"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       wrapMode="ELLIPSIS">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_PosNum"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="8"
-                                                                offsetY="0" />
-                                                        <DimensionConstraints minX="0"
-                                                                              minY="0"
-                                                                              maxX="200"
-                                                                              maxY="44" />
-                                                </Label>
-                                                <Label name="$(parent)_Priority"
-                                                       horizontalAlignment="RIGHT"
-                                                       verticalAlignment="CENTER"
-                                                       color="B3B3B3"
-                                                       hidden="true">
-                                                        <Anchor point="RIGHT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="-5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Cooldown name="$(parent)_Cooldown"
-                                                          hidden="true"
-                                                          textureFile="EsoUI/Art/ActionBar/abilityHighlight.dds"
-                                                          fillColor="000000B3"
-                                                          desaturation="1">
-                                                        <Anchor point="TOPLEFT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="TOPLEFT" />
-                                                        <Anchor point="BOTTOMRIGHT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="BOTTOMRIGHT" />
-                                                </Cooldown>
-                                                <Label name="$(parent)_CooldownText"
-                                                       horizontalAlignment="CENTER"
-                                                       verticalAlignment="CENTER"
-                                                       color="FFFFFF"
-                                                       hidden="true">
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Label>
-                                        </Controls>
-                                </Control>
-                                <Control name="$(parent)_Row6"
-                                         mouseEnabled="true"
-                                         hidden="true">
-                                        <Dimensions x="320"
-                                                    y="44" />
-                                        <Anchor point="TOP"
-                                                relativeTo="$(parent)_Row5"
-                                                relativePoint="BOTTOM" />
-                                        <Controls>
-                                                <Texture name="$(parent)_IconBg"
-                                                         textureFile="EsoUI/Art/ActionBar/abilityFrame64_up.dds">
-                                                        <Dimensions x="40"
-                                                                    y="40" />
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="LEFT"
-                                                                offsetX="2"
-                                                                offsetY="0" />
-                                                </Texture>
-                                                <Texture name="$(parent)_Icon">
-                                                        <Dimensions x="36"
-                                                                    y="36" />
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Texture>
-                                                <Label name="$(parent)_PosNum"
-                                                       font="ZoFontGamepad27"
-                                                       color="FFFF80"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       text="6"
-                                                       hidden="true">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Label name="$(parent)_Name"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       wrapMode="ELLIPSIS">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_PosNum"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="8"
-                                                                offsetY="0" />
-                                                        <DimensionConstraints minX="0"
-                                                                              minY="0"
-                                                                              maxX="200"
-                                                                              maxY="44" />
-                                                </Label>
-                                                <Label name="$(parent)_Priority"
-                                                       horizontalAlignment="RIGHT"
-                                                       verticalAlignment="CENTER"
-                                                       color="B3B3B3"
-                                                       hidden="true">
-                                                        <Anchor point="RIGHT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="-5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Cooldown name="$(parent)_Cooldown"
-                                                          hidden="true"
-                                                          textureFile="EsoUI/Art/ActionBar/abilityHighlight.dds"
-                                                          fillColor="000000B3"
-                                                          desaturation="1">
-                                                        <Anchor point="TOPLEFT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="TOPLEFT" />
-                                                        <Anchor point="BOTTOMRIGHT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="BOTTOMRIGHT" />
-                                                </Cooldown>
-                                                <Label name="$(parent)_CooldownText"
-                                                       horizontalAlignment="CENTER"
-                                                       verticalAlignment="CENTER"
-                                                       color="FFFFFF"
-                                                       hidden="true">
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Label>
-                                        </Controls>
-                                </Control>
-                                <Control name="$(parent)_Row7"
-                                         mouseEnabled="true"
-                                         hidden="true">
-                                        <Dimensions x="320"
-                                                    y="44" />
-                                        <Anchor point="TOP"
-                                                relativeTo="$(parent)_Row6"
-                                                relativePoint="BOTTOM" />
-                                        <Controls>
-                                                <Texture name="$(parent)_IconBg"
-                                                         textureFile="EsoUI/Art/ActionBar/abilityFrame64_up.dds">
-                                                        <Dimensions x="40"
-                                                                    y="40" />
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="LEFT"
-                                                                offsetX="2"
-                                                                offsetY="0" />
-                                                </Texture>
-                                                <Texture name="$(parent)_Icon">
-                                                        <Dimensions x="36"
-                                                                    y="36" />
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Texture>
-                                                <Label name="$(parent)_PosNum"
-                                                       font="ZoFontGamepad27"
-                                                       color="FFFF80"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       text="7"
-                                                       hidden="true">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Label name="$(parent)_Name"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       wrapMode="ELLIPSIS">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_PosNum"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="8"
-                                                                offsetY="0" />
-                                                        <DimensionConstraints minX="0"
-                                                                              minY="0"
-                                                                              maxX="200"
-                                                                              maxY="44" />
-                                                </Label>
-                                                <Label name="$(parent)_Priority"
-                                                       horizontalAlignment="RIGHT"
-                                                       verticalAlignment="CENTER"
-                                                       color="B3B3B3"
-                                                       hidden="true">
-                                                        <Anchor point="RIGHT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="-5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Cooldown name="$(parent)_Cooldown"
-                                                          hidden="true"
-                                                          textureFile="EsoUI/Art/ActionBar/abilityHighlight.dds"
-                                                          fillColor="000000B3"
-                                                          desaturation="1">
-                                                        <Anchor point="TOPLEFT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="TOPLEFT" />
-                                                        <Anchor point="BOTTOMRIGHT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="BOTTOMRIGHT" />
-                                                </Cooldown>
-                                                <Label name="$(parent)_CooldownText"
-                                                       horizontalAlignment="CENTER"
-                                                       verticalAlignment="CENTER"
-                                                       color="FFFFFF"
-                                                       hidden="true">
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Label>
-                                        </Controls>
-                                </Control>
-                                <Control name="$(parent)_Row8"
-                                         mouseEnabled="true"
-                                         hidden="true">
-                                        <Dimensions x="320"
-                                                    y="44" />
-                                        <Anchor point="TOP"
-                                                relativeTo="$(parent)_Row7"
-                                                relativePoint="BOTTOM" />
-                                        <Controls>
-                                                <Texture name="$(parent)_IconBg"
-                                                         textureFile="EsoUI/Art/ActionBar/abilityFrame64_up.dds">
-                                                        <Dimensions x="40"
-                                                                    y="40" />
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="LEFT"
-                                                                offsetX="2"
-                                                                offsetY="0" />
-                                                </Texture>
-                                                <Texture name="$(parent)_Icon">
-                                                        <Dimensions x="36"
-                                                                    y="36" />
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Texture>
-                                                <Label name="$(parent)_PosNum"
-                                                       font="ZoFontGamepad27"
-                                                       color="FFFF80"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       text="8"
-                                                       hidden="true">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Label name="$(parent)_Name"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       wrapMode="ELLIPSIS">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_PosNum"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="8"
-                                                                offsetY="0" />
-                                                        <DimensionConstraints minX="0"
-                                                                              minY="0"
-                                                                              maxX="200"
-                                                                              maxY="44" />
-                                                </Label>
-                                                <Label name="$(parent)_Priority"
-                                                       horizontalAlignment="RIGHT"
-                                                       verticalAlignment="CENTER"
-                                                       color="B3B3B3"
-                                                       hidden="true">
-                                                        <Anchor point="RIGHT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="-5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Cooldown name="$(parent)_Cooldown"
-                                                          hidden="true"
-                                                          textureFile="EsoUI/Art/ActionBar/abilityHighlight.dds"
-                                                          fillColor="000000B3"
-                                                          desaturation="1">
-                                                        <Anchor point="TOPLEFT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="TOPLEFT" />
-                                                        <Anchor point="BOTTOMRIGHT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="BOTTOMRIGHT" />
-                                                </Cooldown>
-                                                <Label name="$(parent)_CooldownText"
-                                                       horizontalAlignment="CENTER"
-                                                       verticalAlignment="CENTER"
-                                                       color="FFFFFF"
-                                                       hidden="true">
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Label>
-                                        </Controls>
-                                </Control>
-                                <Control name="$(parent)_Row9"
-                                         mouseEnabled="true"
-                                         hidden="true">
-                                        <Dimensions x="320"
-                                                    y="44" />
-                                        <Anchor point="TOP"
-                                                relativeTo="$(parent)_Row8"
-                                                relativePoint="BOTTOM" />
-                                        <Controls>
-                                                <Texture name="$(parent)_IconBg"
-                                                         textureFile="EsoUI/Art/ActionBar/abilityFrame64_up.dds">
-                                                        <Dimensions x="40"
-                                                                    y="40" />
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="LEFT"
-                                                                offsetX="2"
-                                                                offsetY="0" />
-                                                </Texture>
-                                                <Texture name="$(parent)_Icon">
-                                                        <Dimensions x="36"
-                                                                    y="36" />
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Texture>
-                                                <Label name="$(parent)_PosNum"
-                                                       font="ZoFontGamepad27"
-                                                       color="FFFF80"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       text="9"
-                                                       hidden="true">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Label name="$(parent)_Name"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       wrapMode="ELLIPSIS">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_PosNum"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="8"
-                                                                offsetY="0" />
-                                                        <DimensionConstraints minX="0"
-                                                                              minY="0"
-                                                                              maxX="200"
-                                                                              maxY="44" />
-                                                </Label>
-                                                <Label name="$(parent)_Priority"
-                                                       horizontalAlignment="RIGHT"
-                                                       verticalAlignment="CENTER"
-                                                       color="B3B3B3"
-                                                       hidden="true">
-                                                        <Anchor point="RIGHT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="-5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Cooldown name="$(parent)_Cooldown"
-                                                          hidden="true"
-                                                          textureFile="EsoUI/Art/ActionBar/abilityHighlight.dds"
-                                                          fillColor="000000B3"
-                                                          desaturation="1">
-                                                        <Anchor point="TOPLEFT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="TOPLEFT" />
-                                                        <Anchor point="BOTTOMRIGHT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="BOTTOMRIGHT" />
-                                                </Cooldown>
-                                                <Label name="$(parent)_CooldownText"
-                                                       horizontalAlignment="CENTER"
-                                                       verticalAlignment="CENTER"
-                                                       color="FFFFFF"
-                                                       hidden="true">
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Label>
-                                        </Controls>
-                                </Control>
-                                <Control name="$(parent)_Row10"
-                                         mouseEnabled="true"
-                                         hidden="true">
-                                        <Dimensions x="320"
-                                                    y="44" />
-                                        <Anchor point="TOP"
-                                                relativeTo="$(parent)_Row9"
-                                                relativePoint="BOTTOM" />
-                                        <Controls>
-                                                <Texture name="$(parent)_IconBg"
-                                                         textureFile="EsoUI/Art/ActionBar/abilityFrame64_up.dds">
-                                                        <Dimensions x="40"
-                                                                    y="40" />
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="LEFT"
-                                                                offsetX="2"
-                                                                offsetY="0" />
-                                                </Texture>
-                                                <Texture name="$(parent)_Icon">
-                                                        <Dimensions x="36"
-                                                                    y="36" />
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Texture>
-                                                <Label name="$(parent)_PosNum"
-                                                       font="ZoFontGamepad27"
-                                                       color="FFFF80"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       text="10"
-                                                       hidden="true">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Label name="$(parent)_Name"
-                                                       horizontalAlignment="LEFT"
-                                                       verticalAlignment="CENTER"
-                                                       wrapMode="ELLIPSIS">
-                                                        <Anchor point="LEFT"
-                                                                relativeTo="$(parent)_PosNum"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="8"
-                                                                offsetY="0" />
-                                                        <DimensionConstraints minX="0"
-                                                                              minY="0"
-                                                                              maxX="200"
-                                                                              maxY="44" />
-                                                </Label>
-                                                <Label name="$(parent)_Priority"
-                                                       horizontalAlignment="RIGHT"
-                                                       verticalAlignment="CENTER"
-                                                       color="B3B3B3"
-                                                       hidden="true">
-                                                        <Anchor point="RIGHT"
-                                                                relativeTo="$(parent)"
-                                                                relativePoint="RIGHT"
-                                                                offsetX="-5"
-                                                                offsetY="0" />
-                                                </Label>
-                                                <Cooldown name="$(parent)_Cooldown"
-                                                          hidden="true"
-                                                          textureFile="EsoUI/Art/ActionBar/abilityHighlight.dds"
-                                                          fillColor="000000B3"
-                                                          desaturation="1">
-                                                        <Anchor point="TOPLEFT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="TOPLEFT" />
-                                                        <Anchor point="BOTTOMRIGHT"
-                                                                relativeTo="$(parent)_Icon"
-                                                                relativePoint="BOTTOMRIGHT" />
-                                                </Cooldown>
-                                                <Label name="$(parent)_CooldownText"
-                                                       horizontalAlignment="CENTER"
-                                                       verticalAlignment="CENTER"
-                                                       color="FFFFFF"
-                                                       hidden="true">
-                                                        <Anchor point="CENTER"
-                                                                relativeTo="$(parent)_IconBg"
-                                                                relativePoint="CENTER" />
-                                                </Label>
-                                        </Controls>
-                                </Control>
-                                <!-- Console Preview Elements -->
-                                <Backdrop name="$(parent)_Preview"
-                                          hidden="true"
-                                          centerColor="0D99E640"
-                                          edgeColor="0D99E6E6">
-                                        <AnchorFill />
-                                </Backdrop>
-                                <Label name="$(parent)_Preview_CoordLabel"
-                                       font="ZoFontGameSmall"
-                                       color="FFFF00"
-                                       text="xxx, yyy"
-                                       hidden="true">
-                                        <Anchor point="TOPLEFT"
-                                                relativeTo="$(parent)_Preview"
-                                                relativePoint="TOPLEFT"
-                                                offsetX="4"
-                                                offsetY="4" />
-                                </Label>
-                                <Label name="$(parent)_Preview_Label"
-                                       font="LUIE Default Font"
-                                       color="FFFFFF"
-                                       horizontalAlignment="CENTER"
-                                       verticalAlignment="CENTER"
-                                       text="Synergy Tracker"
-                                       hidden="true">
-                                        <Anchor point="CENTER"
-                                                relativeTo="$(parent)_Preview"
-                                                relativePoint="CENTER" />
-                                </Label>
-                        </Controls>
-                </TopLevelControl>
-        </Controls>
+  <Controls>
+    <!-- Virtual template for a single synergy row — instantiated dynamically in Lua via
+    CreateControlFromVirtual -->
+    <Control name="LUIE_SynergyTracker_RowTemplate"
+             mouseEnabled="true"
+             hidden="true"
+             virtual="true">
+      <Dimensions x="320"
+                  y="44" />
+      <Controls>
+        <Texture name="$(parent)_IconBg"
+                 textureFile="EsoUI/Art/ActionBar/abilityFrame64_up.dds">
+          <Dimensions x="40"
+                      y="40" />
+          <Anchor point="LEFT"
+                  relativeTo="$(parent)"
+                  relativePoint="LEFT"
+                  offsetX="2"
+                  offsetY="0" />
+        </Texture>
+        <Texture name="$(parent)_Icon">
+          <Dimensions x="36"
+                      y="36" />
+          <Anchor point="CENTER"
+                  relativeTo="$(parent)_IconBg"
+                  relativePoint="CENTER" />
+        </Texture>
+        <Label name="$(parent)_PosNum"
+               font="ZoFontGamepad27"
+               color="FFFF80"
+               horizontalAlignment="LEFT"
+               verticalAlignment="CENTER"
+               hidden="true">
+          <Anchor point="LEFT"
+                  relativeTo="$(parent)_IconBg"
+                  relativePoint="RIGHT"
+                  offsetX="5"
+                  offsetY="0" />
+        </Label>
+        <Label name="$(parent)_Name"
+               horizontalAlignment="LEFT"
+               verticalAlignment="CENTER"
+               wrapMode="ELLIPSIS">
+          <Anchor point="LEFT"
+                  relativeTo="$(parent)_PosNum"
+                  relativePoint="RIGHT"
+                  offsetX="8"
+                  offsetY="0" />
+          <DimensionConstraints minX="0"
+                                minY="0"
+                                maxX="200"
+                                maxY="44" />
+        </Label>
+        <Label name="$(parent)_Priority"
+               horizontalAlignment="RIGHT"
+               verticalAlignment="CENTER"
+               color="B3B3B3"
+               hidden="true">
+          <Anchor point="RIGHT"
+                  relativeTo="$(parent)"
+                  relativePoint="RIGHT"
+                  offsetX="-5"
+                  offsetY="0" />
+        </Label>
+        <Cooldown name="$(parent)_Cooldown"
+                  hidden="true"
+                  textureFile="EsoUI/Art/ActionBar/abilityHighlight.dds"
+                  fillColor="000000B3"
+                  desaturation="1">
+          <Anchor point="TOPLEFT"
+                  relativeTo="$(parent)_Icon"
+                  relativePoint="TOPLEFT" />
+          <Anchor point="BOTTOMRIGHT"
+                  relativeTo="$(parent)_Icon"
+                  relativePoint="BOTTOMRIGHT" />
+        </Cooldown>
+        <Label name="$(parent)_CooldownText"
+               horizontalAlignment="CENTER"
+               verticalAlignment="CENTER"
+               color="FFFFFF"
+               hidden="true">
+          <Anchor point="CENTER"
+                  relativeTo="$(parent)_IconBg"
+                  relativePoint="CENTER" />
+        </Label>
+      </Controls>
+    </Control>
+
+    <TopLevelControl name="LUIE_SynergyTracker_UI"
+                     mouseEnabled="false"
+                     movable="false"
+                     clampedToScreen="true"
+                     hidden="true"
+                     layer="0"
+                     level="1"
+                     tier="1">
+      <Dimensions x="320"
+                  y="440" />
+      <Anchor point="CENTER"
+              relativeTo="GuiRoot"
+              relativePoint="CENTER"
+              offsetX="0"
+              offsetY="200" />
+      <Controls>
+        <Backdrop name="$(parent)_Background"
+                  hidden="true"
+                  centerColor="00000080"
+                  edgeColor="4D4D4DCC">
+          <AnchorFill />
+        </Backdrop>
+      </Controls>
+    </TopLevelControl>
+  </Controls>
 </GuiXml>

--- a/LuiExtended/frontend/UnitFrames.xml
+++ b/LuiExtended/frontend/UnitFrames.xml
@@ -2986,8 +2986,7 @@
               </Controls>
             </Backdrop>
             <Control name="$(parent)_LibGroupContainer"
-                     hidden="false">
-            </Control>
+                     hidden="false" />
             <Backdrop name="$(parent)_ResourceMagicka"
                       centerColor="66000000"
                       edgeColor="99000000"
@@ -3183,8 +3182,7 @@
               </Controls>
             </Backdrop>
             <Control name="$(parent)_LibGroupContainer"
-                     hidden="false">
-            </Control>
+                     hidden="false" />
             <Backdrop name="$(parent)_ResourceMagicka"
                       centerColor="66000000"
                       edgeColor="99000000"
@@ -3379,8 +3377,7 @@
               </Controls>
             </Backdrop>
             <Control name="$(parent)_LibGroupContainer"
-                     hidden="false">
-            </Control>
+                     hidden="false" />
             <Backdrop name="$(parent)_ResourceMagicka"
                       centerColor="66000000"
                       edgeColor="99000000"
@@ -3575,8 +3572,7 @@
               </Controls>
             </Backdrop>
             <Control name="$(parent)_LibGroupContainer"
-                     hidden="false">
-            </Control>
+                     hidden="false" />
             <Backdrop name="$(parent)_ResourceMagicka"
                       centerColor="66000000"
                       edgeColor="99000000"
@@ -3771,8 +3767,7 @@
               </Controls>
             </Backdrop>
             <Control name="$(parent)_LibGroupContainer"
-                     hidden="false">
-            </Control>
+                     hidden="false" />
             <Backdrop name="$(parent)_ResourceMagicka"
                       centerColor="66000000"
                       edgeColor="99000000"
@@ -3967,8 +3962,7 @@
               </Controls>
             </Backdrop>
             <Control name="$(parent)_LibGroupContainer"
-                     hidden="false">
-            </Control>
+                     hidden="false" />
             <Backdrop name="$(parent)_ResourceMagicka"
                       centerColor="66000000"
                       edgeColor="99000000"
@@ -4163,8 +4157,7 @@
               </Controls>
             </Backdrop>
             <Control name="$(parent)_LibGroupContainer"
-                     hidden="false">
-            </Control>
+                     hidden="false" />
             <Backdrop name="$(parent)_ResourceMagicka"
                       centerColor="66000000"
                       edgeColor="99000000"
@@ -4359,8 +4352,7 @@
               </Controls>
             </Backdrop>
             <Control name="$(parent)_LibGroupContainer"
-                     hidden="false">
-            </Control>
+                     hidden="false" />
             <Backdrop name="$(parent)_ResourceMagicka"
                       centerColor="66000000"
                       edgeColor="99000000"
@@ -4555,8 +4547,7 @@
               </Controls>
             </Backdrop>
             <Control name="$(parent)_LibGroupContainer"
-                     hidden="false">
-            </Control>
+                     hidden="false" />
             <Backdrop name="$(parent)_ResourceMagicka"
                       centerColor="66000000"
                       edgeColor="99000000"
@@ -4751,8 +4742,7 @@
               </Controls>
             </Backdrop>
             <Control name="$(parent)_LibGroupContainer"
-                     hidden="false">
-            </Control>
+                     hidden="false" />
             <Backdrop name="$(parent)_ResourceMagicka"
                       centerColor="66000000"
                       edgeColor="99000000"
@@ -4947,8 +4937,7 @@
               </Controls>
             </Backdrop>
             <Control name="$(parent)_LibGroupContainer"
-                     hidden="false">
-            </Control>
+                     hidden="false" />
             <Backdrop name="$(parent)_ResourceMagicka"
                       centerColor="66000000"
                       edgeColor="99000000"
@@ -5143,8 +5132,7 @@
               </Controls>
             </Backdrop>
             <Control name="$(parent)_LibGroupContainer"
-                     hidden="false">
-            </Control>
+                     hidden="false" />
             <Backdrop name="$(parent)_ResourceMagicka"
                       centerColor="66000000"
                       edgeColor="99000000"

--- a/LuiExtended/modules/CombatInfo/Namespace.lua
+++ b/LuiExtended/modules/CombatInfo/Namespace.lua
@@ -238,7 +238,6 @@ CombatInfo.Defaults =
         offsetY = 200,
         detectedSynergies = {},
         priorityOverrides = {},
-        cooldownGroups = {},
         blacklist = {},
     },
     block =

--- a/LuiExtended/modules/CombatInfo/SynergyTracker.lua
+++ b/LuiExtended/modules/CombatInfo/SynergyTracker.lua
@@ -335,7 +335,7 @@ function SynergyTracker:UpdateDisplay()
         -- Build a candidate list and sort by priority, since index order is not priority order.
         local singleCandidates = {}
         for i = 1, numSynergies do
-            local name, icon, prompt, priority, abilityId, canBeUsed = GetSynergyInfoAtIndex(i)
+            local name, icon, prompt, priority, abilityId = GetSynergyInfoAtIndex(i)
             if abilityId and abilityId > 0 and not Settings.blacklist[abilityId] then
                 table.insert(singleCandidates,
                              {
@@ -345,7 +345,6 @@ function SynergyTracker:UpdateDisplay()
                                  prompt = prompt,
                                  priority = Settings.priorityOverrides[abilityId] or priority or 0,
                                  abilityId = abilityId,
-                                 canBeUsed = canBeUsed,
                              })
             end
         end
@@ -370,14 +369,14 @@ function SynergyTracker:UpdateDisplay()
         local showPrompt = topSynergy and topSynergy.prompt
         local showAbilityId = topSynergy and topSynergy.abilityId
 
-        local hasSynergy = showName ~= nil
+        local hasSynergy = topSynergy ~= nil
         if hasSynergy and self.synergyControls[1] then
             local control = self.synergyControls[1]
             if control.icon then
                 control.icon:SetTexture(showIcon)
             end
             if control.name then
-                control.name:SetText(showPrompt ~= "" and showPrompt or showName)
+                control.name:SetText((showPrompt and showPrompt ~= "") and showPrompt or (showName or ""))
             end
             if control.priority then
                 control.priority:SetHidden(true)

--- a/LuiExtended/modules/CombatInfo/SynergyTracker.lua
+++ b/LuiExtended/modules/CombatInfo/SynergyTracker.lua
@@ -332,17 +332,43 @@ function SynergyTracker:UpdateDisplay()
     end
 
     if displayMode == "single" then
-        -- Iterate in priority order and pick the first non-blacklisted available synergy
-        local showName, showIcon, showPrompt
+        -- Build a candidate list and sort by priority, since index order is not priority order.
+        local singleCandidates = {}
         for i = 1, numSynergies do
             local name, icon, prompt, priority, abilityId, canBeUsed = GetSynergyInfoAtIndex(i)
             if abilityId and abilityId > 0 and not Settings.blacklist[abilityId] then
-                showName = name
-                showIcon = icon
-                showPrompt = prompt
-                break
+                table.insert(singleCandidates,
+                             {
+                                 index = i,
+                                 name = name,
+                                 icon = icon,
+                                 prompt = prompt,
+                                 priority = Settings.priorityOverrides[abilityId] or priority or 0,
+                                 abilityId = abilityId,
+                                 canBeUsed = canBeUsed,
+                             })
             end
         end
+
+        table.sort(singleCandidates, function (a, b)
+            if a.priority ~= b.priority then
+                return a.priority > b.priority
+            end
+
+            local aName = a.name or ""
+            local bName = b.name or ""
+            if aName ~= bName then
+                return aName < bName
+            end
+
+            return a.index < b.index
+        end)
+
+        local topSynergy = singleCandidates[1]
+        local showName = topSynergy and topSynergy.name
+        local showIcon = topSynergy and topSynergy.icon
+        local showPrompt = topSynergy and topSynergy.prompt
+        local showAbilityId = topSynergy and topSynergy.abilityId
 
         local hasSynergy = showName ~= nil
         if hasSynergy and self.synergyControls[1] then
@@ -359,6 +385,7 @@ function SynergyTracker:UpdateDisplay()
             if control.posNum then
                 control.posNum:SetHidden(true)
             end
+            control.abilityId = showAbilityId
             control.row:SetHidden(false)
         end
 

--- a/LuiExtended/modules/CombatInfo/SynergyTracker.lua
+++ b/LuiExtended/modules/CombatInfo/SynergyTracker.lua
@@ -26,9 +26,7 @@ local moduleName = LUIE.name .. "CombatInfo" .. "SynergyTracker"
 
 -- UI Constants
 local MAX_SYNERGY_SLOTS = 10
-local SYNERGY_ROW_HEIGHT = 44
-local SYNERGY_ROW_WIDTH = 320
-local SYNERGY_ICON_SIZE = 40
+local PREVIEW_ROW_COUNT = 3
 
 --- Hardcoded shared cooldown groups
 --- Wiki: "Luminous Shards and Energy Orb's synergies uniquely share the same cooldown"
@@ -42,15 +40,23 @@ local HARDCODED_SHARED_COOLDOWNS =
     [88758] = { 26832, 95922, 39301, 88758 }, -- Healing Combustion (Energy Orb)
 }
 
+--- Set font on a label, selecting between PC and console variants
+--- @param label LabelControl|nil
+--- @param pcFont string Font for keyboard/mouse mode
+--- @param consoleFont string Font for gamepad/console mode
+local function SetLabelFont(label, pcFont, consoleFont)
+    if label then
+        label:SetFont((IsConsoleUI() or IsInGamepadPreferredMode()) and consoleFont or pcFont)
+    end
+end
+
 --- @class SynergyTracker : ZO_Object
 --- @field control TopLevelWindow Main UI control
 --- @field bg LUIE_SynergyTracker_UI_Background Background control for unlock mode
 --- @field activeSynergies table<integer, table> Currently active synergies
 --- @field synergyControls table[] UI controls for each synergy slot
 --- @field synergyCooldowns table<integer, table> Synergies currently on cooldown
---- @field lastSynergyCount integer Last known synergy count
 --- @field lastCooldownUpdate integer Last cooldown UI update time
---- @field lastLoggedCooldownCount integer Last logged cooldown count (for debug)
 local SynergyTracker = ZO_Object:Subclass()
 CombatInfo.SynergyTracker = SynergyTracker
 
@@ -62,15 +68,12 @@ function SynergyTracker:New()
     return obj
 end
 
---- Initialize the SynergyTracker (loads controls from XML, creates fragment, registers events)
+--- Initialize the SynergyTracker (creates rows from virtual template, creates fragment, registers events)
 function SynergyTracker:Initialize()
     self.activeSynergies = {}
     self.synergyControls = {}
-    self.lastSynergyCount = 0
     self.synergyCooldowns = {}
-    self.lastLoggedCooldownCount = 0
 
-    -- Get control from XML
     local mainControl = LUIE_SynergyTracker_UI
     if not mainControl then
         return
@@ -78,98 +81,82 @@ function SynergyTracker:Initialize()
 
     self.control = mainControl
 
-    -- Get background control
     self.bg = LUIE_SynergyTracker_UI_Background
     if self.bg then
-        -- Set backdrop colors (XML sets defaults, but we may need to adjust)
         self.bg:SetCenterColor(0, 0, 0, 0.5)
         self.bg:SetEdgeColor(0.3, 0.3, 0.3, 0.8)
         self.bg:SetEdgeTexture("", 1, 1, 0, 0)
     end
 
-    -- Load synergy row controls from XML
+    -- Instantiate synergy rows from the virtual template
     for i = 1, MAX_SYNERGY_SLOTS do
-        local row = GetControl("LUIE_SynergyTracker_UI_Row" .. i)
-        if row then
-            local iconBg = GetControl("LUIE_SynergyTracker_UI_Row" .. i .. "_IconBg")             --- @type TextureControl
-            local icon = GetControl("LUIE_SynergyTracker_UI_Row" .. i .. "_Icon")                 --- @type TextureControl
-            local posNum = GetControl("LUIE_SynergyTracker_UI_Row" .. i .. "_PosNum")             --- @type LabelControl
-            local name = GetControl("LUIE_SynergyTracker_UI_Row" .. i .. "_Name")                 --- @type LabelControl
-            local priority = GetControl("LUIE_SynergyTracker_UI_Row" .. i .. "_Priority")         --- @type LabelControl
-            local cooldown = GetControl("LUIE_SynergyTracker_UI_Row" .. i .. "_Cooldown")         --- @type CooldownControl
-            local cooldownText = GetControl("LUIE_SynergyTracker_UI_Row" .. i .. "_CooldownText") --- @type LabelControl
+        local row = CreateControlFromVirtual("LUIE_SynergyTracker_UI_Row" .. i, self.control, "LUIE_SynergyTracker_RowTemplate")
 
-            -- Set fonts based on platform
-            if name then
-                if IsConsoleUI() or IsInGamepadPreferredMode() then
-                    name:SetFont("$(GAMEPAD_MEDIUM_FONT)|18|soft-shadow-thick")
-                else
-                    name:SetFont("ZoInteractionPrompt")
-                end
-            end
-
-            if priority then
-                if IsConsoleUI() or IsInGamepadPreferredMode() then
-                    priority:SetFont("$(GAMEPAD_MEDIUM_FONT)|16|soft-shadow-thick")
-                else
-                    priority:SetFont("ZoFontGame")
-                end
-            end
-
-            if cooldownText then
-                if IsConsoleUI() or IsInGamepadPreferredMode() then
-                    cooldownText:SetFont("$(GAMEPAD_MEDIUM_FONT)|20|soft-shadow-thick")
-                else
-                    cooldownText:SetFont("ZoFontGameBold")
-                end
-            end
-
-            -- Set up tooltip handlers
-            if row then
-                row:SetHandler("OnMouseEnter", function (control)
-                    local abilityId = self.synergyControls[i].abilityId
-                    if abilityId and abilityId > 0 then
-                        InitializeTooltip(GameTooltip, control, BOTTOM, 0, -5, TOP)
-
-                        local abilityName = zo_strformat(SI_ABILITY_NAME, GetAbilityName(abilityId))
-                        GameTooltip:AddLine(abilityName, "ZoFontHeader2", 1, 1, 1, nil)
-
-                        if not IsAbilityPassive(abilityId) then
-                            local description = GetAbilityDescription(abilityId, nil, "player")
-                            if description and description ~= "" then
-                                GameTooltip:SetVerticalPadding(1)
-                                ZO_Tooltip_AddDivider(GameTooltip)
-                                GameTooltip:SetVerticalPadding(5)
-                                GameTooltip:AddLine(description, "", ZO_NORMAL_TEXT:UnpackRGBA())
-                            end
-                        end
-                    end
-                end)
-
-                row:SetHandler("OnMouseExit", function ()
-                    ClearTooltip(GameTooltip)
-                end)
-            end
-
-            self.synergyControls[i] =
-            {
-                row = row,
-                iconBg = iconBg,
-                icon = icon,
-                posNum = posNum,
-                name = name,
-                priority = priority,
-                cooldown = cooldown,
-                cooldownText = cooldownText,
-                abilityId = nil,
-            }
+        if i == 1 then
+            row:SetAnchor(TOP, self.control, TOP, 0, 0)
+        else
+            row:SetAnchor(TOP, self.synergyControls[i - 1].row, BOTTOM, 0, 0)
         end
+
+        local iconBg = row:GetNamedChild("_IconBg")             --- @type TextureControl
+        local icon = row:GetNamedChild("_Icon")                 --- @type TextureControl
+        local posNum = row:GetNamedChild("_PosNum")             --- @type LabelControl
+        local name = row:GetNamedChild("_Name")                 --- @type LabelControl
+        local priority = row:GetNamedChild("_Priority")         --- @type LabelControl
+        local cooldown = row:GetNamedChild("_Cooldown")         --- @type CooldownControl
+        local cooldownText = row:GetNamedChild("_CooldownText") --- @type LabelControl
+
+        if posNum then
+            posNum:SetText(tostring(i))
+        end
+
+        SetLabelFont(name, "ZoInteractionPrompt", "$(GAMEPAD_MEDIUM_FONT)|18|soft-shadow-thick")
+        SetLabelFont(priority, "ZoFontGame", "$(GAMEPAD_MEDIUM_FONT)|16|soft-shadow-thick")
+        SetLabelFont(cooldownText, "ZoFontGameBold", "$(GAMEPAD_MEDIUM_FONT)|20|soft-shadow-thick")
+
+        row:SetHandler("OnMouseEnter", function (control)
+            local abilityId = self.synergyControls[i].abilityId
+            if abilityId and abilityId > 0 then
+                InitializeTooltip(GameTooltip, control, BOTTOM, 0, -5, TOP)
+
+                local abilityName = zo_strformat(SI_ABILITY_NAME, GetAbilityName(abilityId))
+                GameTooltip:AddLine(abilityName, "ZoFontHeader2", 1, 1, 1, nil)
+
+                if not IsAbilityPassive(abilityId) then
+                    local description = GetAbilityDescription(abilityId, nil, "player")
+                    if description and description ~= "" then
+                        GameTooltip:SetVerticalPadding(1)
+                        ZO_Tooltip_AddDivider(GameTooltip)
+                        GameTooltip:SetVerticalPadding(5)
+                        GameTooltip:AddLine(description, "", ZO_NORMAL_TEXT:UnpackRGBA())
+                    end
+                end
+            end
+        end)
+
+        row:SetHandler("OnMouseExit", function ()
+            ClearTooltip(GameTooltip)
+        end)
+
+        self.synergyControls[i] =
+        {
+            row = row,
+            iconBg = iconBg,
+            icon = icon,
+            posNum = posNum,
+            name = name,
+            priority = priority,
+            cooldown = cooldown,
+            cooldownText = cooldownText,
+            abilityId = nil,
+        }
     end
 
-    -- Initialize position and settings
     local Settings = CombatInfo.SV.synergy
 
-    -- Register for HUD and HUDUI scene state changes to show/hide control
+    -- Migrate away from the old cooldownGroups saved variable field
+    Settings.cooldownGroups = nil
+
     local hudScene = sceneManager:GetScene(HUD_SCENE)
     local hudUIScene = sceneManager:GetScene(HUDUI_SCENE)
 
@@ -180,7 +167,6 @@ function SynergyTracker:Initialize()
         else
             LUIE_callLater(function () self:OnHidden() end, 0)
         end
-        -- Show/hide control based on scene state (unless unlocked for positioning)
         if not Settings.unlocked then
             self.control:SetHidden(not isShown)
         end
@@ -189,7 +175,6 @@ function SynergyTracker:Initialize()
     hudScene:RegisterCallback("StateChange", OnSceneStateChange)
     hudUIScene:RegisterCallback("StateChange", OnSceneStateChange)
 
-    -- Initial state check
     local currentScene = sceneManager:GetCurrentScene()
     if currentScene == hudScene or currentScene == hudUIScene then
         if currentScene:GetState() == SCENE_SHOWN then
@@ -199,32 +184,24 @@ function SynergyTracker:Initialize()
         self.control:SetHidden(true)
     end
 
-    -- Fragment for console settings scene so preview is visible while addon settings are open
     self.settingsSceneFragment = ZO_HUDFadeSceneFragment:New(self.control, 0, 0)
 
-    -- Restore saved position or use default
     self:ApplyPosition()
 
-    -- Update movable state based on settings
     self.control:SetMovable(Settings.unlocked)
     self.control:SetMouseEnabled(Settings.unlocked)
 
-    -- Set background visibility
     if self.bg then
         self.bg:SetHidden(not Settings.unlocked)
     end
 
-    -- Unlock/lock handlers
     self.control:SetHandler("OnMoveStop", function ()
-        -- Convert center coordinates to offset from GuiRoot center
         local centerX, centerY = self.control:GetCenter()
         Settings.offsetX = centerX - GuiRoot:GetWidth() / 2
         Settings.offsetY = centerY - GuiRoot:GetHeight() / 2
     end)
 
-    -- Cooldown timer update loop (updates every second)
     self.lastCooldownUpdate = 0
-    -- Note: OnUpdate is handled in XML, but we'll also set it here for safety
     self.control:SetHandler("OnUpdate", function ()
         local currentTime = GetGameTimeMilliseconds()
         if currentTime - self.lastCooldownUpdate >= 1000 then
@@ -233,49 +210,21 @@ function SynergyTracker:Initialize()
         end
     end)
 
-    -- Register events
     eventManager:RegisterForEvent(moduleName, EVENT_PLAYER_ACTIVATED, function () self:OnSynergyAbilityChanged() end)
     eventManager:RegisterForEvent(moduleName, EVENT_SYNERGY_ABILITY_CHANGED, function () self:OnSynergyAbilityChanged() end)
     eventManager:RegisterForEvent(moduleName, EVENT_PLAYER_DEAD, function () self:OnPlayerDead() end)
 
-    -- Combat event for synergy activation detection (filter by player source)
     eventManager:RegisterForEvent(moduleName, EVENT_COMBAT_EVENT, function (eventCode, result, isError, abilityName, abilityGraphic, abilityActionSlotType, sourceName, sourceType, targetName, targetType, hitValue, powerType, damageType, log, sourceUnitId, targetUnitId, abilityId, overflow)
-        self:OnCombatEvent(eventCode, result, isError, abilityName, abilityGraphic, abilityActionSlotType, sourceName, sourceType, targetName, targetType, hitValue, powerType, damageType, log, sourceUnitId, targetUnitId, abilityId, overflow)
+        self:OnCombatEvent(result, abilityId)
     end)
     eventManager:AddFilterForEvent(moduleName, EVENT_COMBAT_EVENT, REGISTER_FILTER_SOURCE_COMBAT_UNIT_TYPE, COMBAT_UNIT_TYPE_PLAYER)
 
-    -- Effect changed for cooldown detection (filter by player unit tag)
     eventManager:RegisterForEvent(moduleName, EVENT_EFFECT_CHANGED, function (eventCode, changeType, effectSlot, effectName, unitTag, beginTime, endTime, stackCount, iconName, deprecatedBuffType, effectType, abilityType, statusEffectType, unitName, unitId, abilityId, sourceType)
-        self:OnEffectChanged(eventCode, changeType, effectSlot, effectName, unitTag, beginTime, endTime, stackCount, iconName, deprecatedBuffType, effectType, abilityType, statusEffectType, unitName, unitId, abilityId, sourceType)
+        self:OnEffectChanged(changeType, abilityId)
     end)
     eventManager:AddFilterForEvent(moduleName, EVENT_EFFECT_CHANGED, REGISTER_FILTER_UNIT_TAG, "player")
 
-    -- Clean up any corrupted cooldown groups from old logic
-    self:CleanupCorruptedCooldownGroups()
-
-    -- Initial synergy check
     LUIE_callLater(function () self:RefreshActiveSynergies() end, 100)
-end
-
---- Static handler for OnMoveStop from XML
-function SynergyTracker.OnMoveStop()
-    if CombatInfo.SynergyTrackerInstance then
-        local Settings = CombatInfo.SV.synergy
-        local centerX, centerY = CombatInfo.SynergyTrackerInstance.control:GetCenter()
-        Settings.offsetX = centerX - GuiRoot:GetWidth() / 2
-        Settings.offsetY = centerY - GuiRoot:GetHeight() / 2
-    end
-end
-
---- Static handler for OnUpdate from XML
-function SynergyTracker.OnUpdate(control)
-    if CombatInfo.SynergyTrackerInstance then
-        local currentTime = GetGameTimeMilliseconds()
-        if currentTime - CombatInfo.SynergyTrackerInstance.lastCooldownUpdate >= 1000 then
-            CombatInfo.SynergyTrackerInstance.lastCooldownUpdate = currentTime
-            CombatInfo.SynergyTrackerInstance:UpdateCooldownDisplay()
-        end
-    end
 end
 
 --- Called when HUD scene is showing
@@ -293,8 +242,7 @@ function SynergyTracker:RefreshActiveSynergies()
     local Settings = CombatInfo.SV.synergy
     local newSynergies = {}
     local numSynergies = GetNumberOfAvailableSynergies()
-
-    local hadNewSynergy = numSynergies > self.lastSynergyCount
+    local prevNonBlacklistedCount = NonContiguousCount(self.activeSynergies)
 
     for i = 1, numSynergies do
         local name, icon, prompt, priority, abilityId, canBeUsed = GetSynergyInfoAtIndex(i)
@@ -333,43 +281,34 @@ function SynergyTracker:RefreshActiveSynergies()
         if not newSynergies[abilityId] then
             self:OnSynergyRemoved(abilityId, data)
         end
-        -- Don't clear cooldowns for synergies that are still active
-        -- They can be active (available) but still on cooldown for the player
     end
 
-    -- Don't clear cooldowns for newly appearing synergies
-    -- The synergy might reappear (someone else cast it) but player still has personal cooldown
-
+    local hadNewSynergy = NonContiguousCount(newSynergies) > prevNonBlacklistedCount
     self.activeSynergies = newSynergies
-    self.lastSynergyCount = numSynergies
 
     local currentTime = GetGameTimeMilliseconds()
     for abilityId, cooldownData in pairs(self.synergyCooldowns) do
-        local elapsed = currentTime - cooldownData.startTime
-        if elapsed >= cooldownData.duration then
+        if currentTime - cooldownData.startTime >= cooldownData.duration then
             self.synergyCooldowns[abilityId] = nil
         end
     end
 
     self:UpdateDisplay()
 
-    if hadNewSynergy and Settings.playSound and numSynergies > 0 then
+    if hadNewSynergy and Settings.playSound then
         PlaySound(SOUNDS.ABILITY_SYNERGY_READY)
     end
 end
 
 --- Update the multi-synergy display
 function SynergyTracker:UpdateDisplay()
-    -- Don't update display if not in HUD/HUDUI scene
     local currentScene = sceneManager:GetCurrentScene()
-    if currentScene ~= sceneManager:GetScene(HUD_SCENE) and currentScene ~= sceneManager:GetScene(HUDUI_SCENE) then
-        return
-    end
-    if currentScene:GetState() ~= SCENE_SHOWN then
+    local hudScene = sceneManager:GetScene(HUD_SCENE)
+    local hudUIScene = sceneManager:GetScene(HUDUI_SCENE)
+    if (currentScene ~= hudScene and currentScene ~= hudUIScene) or currentScene:GetState() ~= SCENE_SHOWN then
         return
     end
 
-    -- Don't update if synergy controls haven't been loaded yet
     if not self.synergyControls or not self.synergyControls[1] then
         return
     end
@@ -393,24 +332,32 @@ function SynergyTracker:UpdateDisplay()
     end
 
     if displayMode == "single" then
-        local hasSynergy, synergyName, iconFilename, prompt = GetCurrentSynergyInfo()
+        -- Iterate in priority order and pick the first non-blacklisted available synergy
+        local showName, showIcon, showPrompt
+        for i = 1, numSynergies do
+            local name, icon, prompt, priority, abilityId, canBeUsed = GetSynergyInfoAtIndex(i)
+            if abilityId and abilityId > 0 and not Settings.blacklist[abilityId] then
+                showName = name
+                showIcon = icon
+                showPrompt = prompt
+                break
+            end
+        end
 
+        local hasSynergy = showName ~= nil
         if hasSynergy and self.synergyControls[1] then
             local control = self.synergyControls[1]
             if control.icon then
-                control.icon:SetTexture(iconFilename)
+                control.icon:SetTexture(showIcon)
             end
             if control.name then
-                control.name:SetText(prompt ~= "" and prompt or synergyName)
+                control.name:SetText(showPrompt ~= "" and showPrompt or showName)
             end
             if control.priority then
                 control.priority:SetHidden(true)
             end
-            if control.cooldown then
-                control.cooldown:SetHidden(true)
-            end
-            if control.cooldownText then
-                control.cooldownText:SetHidden(true)
+            if control.posNum then
+                control.posNum:SetHidden(true)
             end
             control.row:SetHidden(false)
         end
@@ -422,40 +369,25 @@ function SynergyTracker:UpdateDisplay()
 
     local displayList = {}
     local currentTime = GetGameTimeMilliseconds()
-    local activeMap = {}
-
-    for i = 1, numSynergies do
-        local name, icon, prompt, priority, abilityId, canBeUsed = GetSynergyInfoAtIndex(i)
-        if abilityId and abilityId > 0 then
-            activeMap[abilityId] =
-            {
-                name = name,
-                icon = icon,
-                prompt = prompt,
-                priority = priority,
-                canBeUsed = canBeUsed,
-            }
-        end
-    end
 
     for abilityId, synergyData in pairs(Settings.detectedSynergies) do
         if not Settings.blacklist[abilityId] then
-            local isActive = activeMap[abilityId] ~= nil
+            local activeData = self.activeSynergies[abilityId]
+            local isActive = activeData ~= nil
             local cooldownData = self.synergyCooldowns[abilityId]
             local priority = Settings.priorityOverrides[abilityId] or 0
 
             local isOnCooldown = false
             local cooldownRemaining = nil
             if Settings.showCooldowns and cooldownData then
-                local elapsed = currentTime - cooldownData.startTime
-                local remaining = cooldownData.duration - elapsed
+                local remaining = cooldownData.duration - (currentTime - cooldownData.startTime)
                 if remaining > 0 then
                     isOnCooldown = true
                     cooldownRemaining = remaining
                 end
             end
 
-            local displayData = activeMap[abilityId] or
+            local displayData = activeData or
                 {
                     name = synergyData.name,
                     icon = synergyData.icon,
@@ -501,9 +433,15 @@ function SynergyTracker:UpdateDisplay()
             control.icon:SetTexture(synergyData.icon)
         end
 
-        local displayText = synergyData.prompt
-        if displayText == "" or displayMode == "compact" then
+        local displayText
+        if displayMode == "compact" then
             displayText = synergyData.name
+        else
+            -- "multi": prefer the game's prompt string; if empty, build a short action string
+            displayText = synergyData.prompt
+            if displayText == "" then
+                displayText = zo_strformat(SI_USE_SYNERGY, synergyData.name)
+            end
         end
 
         if control.name then
@@ -544,7 +482,7 @@ function SynergyTracker:UpdateDisplay()
     self:UpdateCooldownDisplay()
 end
 
---- Update cooldown timer displays (called every second)
+--- Update cooldown timer displays (called every second via OnUpdate throttle)
 function SynergyTracker:UpdateCooldownDisplay()
     local currentTime = GetGameTimeMilliseconds()
     local Settings = CombatInfo.SV.synergy
@@ -558,8 +496,7 @@ function SynergyTracker:UpdateCooldownDisplay()
 
         if not control.row:IsHidden() and abilityId and self.synergyCooldowns[abilityId] then
             local cooldownData = self.synergyCooldowns[abilityId]
-            local elapsed = currentTime - cooldownData.startTime
-            local remaining = cooldownData.duration - elapsed
+            local remaining = cooldownData.duration - (currentTime - cooldownData.startTime)
 
             if remaining > 0 and Settings.showCooldowns then
                 if control.cooldown then
@@ -574,8 +511,7 @@ function SynergyTracker:UpdateCooldownDisplay()
                 end
 
                 if control.cooldownText then
-                    local seconds = math_ceil(remaining / 1000)
-                    control.cooldownText:SetText(string_format("%d", seconds))
+                    control.cooldownText:SetText(string_format("%d", math_ceil(remaining / 1000)))
                     control.cooldownText:SetHidden(false)
                 end
             else
@@ -597,6 +533,34 @@ function SynergyTracker:UpdateCooldownDisplay()
     end
 end
 
+--- Apply a cooldown for abilityId (and any synergies sharing its cooldown group)
+--- @param abilityId integer Synergy ability ID that triggered the cooldown
+function SynergyTracker:ApplyCooldown(abilityId)
+    local Settings = CombatInfo.SV.synergy
+    if not Settings.showCooldowns then
+        return
+    end
+
+    local duration = GetAbilityCooldown(abilityId, "player")
+    if not duration or duration == 0 then
+        return
+    end
+
+    local now = GetGameTimeMilliseconds()
+    for _, groupId in ipairs(self:GetSharedCooldownGroup(abilityId)) do
+        local data = Settings.detectedSynergies[groupId]
+        if data and not Settings.blacklist[groupId] then
+            self.synergyCooldowns[groupId] =
+            {
+                startTime = now,
+                duration = duration,
+            }
+        end
+    end
+
+    self:UpdateDisplay()
+end
+
 --- Synergy was removed (activated, timed out, or source destroyed)
 --- @param abilityId integer Synergy ability ID
 --- @param data table Synergy data
@@ -607,28 +571,7 @@ function SynergyTracker:OnSynergyRemoved(abilityId, data)
         Settings.detectedSynergies[abilityId].timesSeen = (Settings.detectedSynergies[abilityId].timesSeen or 0) + 1
     end
 
-    local cooldownDuration = GetAbilityCooldown(abilityId, "player")
-
-    if Settings.showCooldowns and cooldownDuration and cooldownDuration > 0 then
-        local currentTime = GetGameTimeMilliseconds()
-        local sharedGroup = self:GetSharedCooldownGroup(abilityId)
-
-        for _, groupAbilityId in ipairs(sharedGroup) do
-            local synergyData = Settings.detectedSynergies[groupAbilityId]
-            if synergyData and not Settings.blacklist[groupAbilityId] then
-                self.synergyCooldowns[groupAbilityId] =
-                {
-                    startTime = currentTime,
-                    duration = cooldownDuration,
-                    name = synergyData.name,
-                    icon = synergyData.icon,
-                    priority = Settings.priorityOverrides[groupAbilityId] or 0,
-                }
-            end
-        end
-
-        self:UpdateDisplay()
-    end
+    self:ApplyCooldown(abilityId)
 end
 
 --- Event: Synergy ability changed (primary event)
@@ -636,33 +579,17 @@ function SynergyTracker:OnSynergyAbilityChanged()
     self:RefreshActiveSynergies()
 end
 
---- Event: Player dead
+--- Event: Player dead — clear all runtime state
 function SynergyTracker:OnPlayerDead()
     ZO_ClearTable(self.activeSynergies)
     ZO_ClearTable(self.synergyCooldowns)
-    self.lastSynergyCount = 0
     self:UpdateDisplay()
 end
 
---- Event: Effect changed (immediate cooldown detection)
---- @param eventCode integer
+--- Event: Effect changed on player (immediate cooldown detection)
 --- @param changeType EffectResult
---- @param effectSlot integer
---- @param effectName string
---- @param unitTag string
---- @param beginTime number
---- @param endTime number
---- @param stackCount integer
---- @param iconName string
---- @param deprecatedBuffType string
---- @param effectType BuffEffectType
---- @param abilityType AbilityType
---- @param statusEffectType StatusEffectType
---- @param unitName string
---- @param unitId integer
 --- @param abilityId integer
---- @param sourceType CombatUnitType
-function SynergyTracker:OnEffectChanged(eventCode, changeType, effectSlot, effectName, unitTag, beginTime, endTime, stackCount, iconName, deprecatedBuffType, effectType, abilityType, statusEffectType, unitName, unitId, abilityId, sourceType)
+function SynergyTracker:OnEffectChanged(changeType, abilityId)
     local Settings = CombatInfo.SV.synergy
 
     if not Settings.showCooldowns then
@@ -678,56 +605,23 @@ function SynergyTracker:OnEffectChanged(eventCode, changeType, effectSlot, effec
     end
 
     if changeType == EFFECT_RESULT_FADED then
-        self:ApplyImmediateCooldown(abilityId)
+        self:ApplyCooldown(abilityId)
     elseif changeType == EFFECT_RESULT_GAINED then
         self.synergyCooldowns[abilityId] = nil
         self:UpdateDisplay()
     end
 end
 
---- Event: Combat event (synergy activation detection)
---- @param eventCode integer
+--- Event: Combat event (synergy activation detection, player source only)
 --- @param result ActionResult
---- @param isError boolean
---- @param abilityName string
---- @param abilityGraphic integer
---- @param abilityActionSlotType ActionSlotType
---- @param sourceName string
---- @param sourceType CombatUnitType
---- @param targetName string
---- @param targetType CombatUnitType
---- @param hitValue integer
---- @param powerType CombatMechanicFlags
---- @param damageType DamageType
---- @param log boolean
---- @param sourceUnitId integer
---- @param targetUnitId integer
 --- @param abilityId integer
---- @param overflow integer
-function SynergyTracker:OnCombatEvent(eventCode, result, isError, abilityName, abilityGraphic, abilityActionSlotType, sourceName, sourceType, targetName, targetType, hitValue, powerType, damageType, log, sourceUnitId, targetUnitId, abilityId, overflow)
+function SynergyTracker:OnCombatEvent(result, abilityId)
     local Settings = CombatInfo.SV.synergy
 
     if Settings.detectedSynergies[abilityId] and not Settings.blacklist[abilityId] then
         if result > 0 and result < 2000 then
-            self:DetectSharedCooldowns(abilityId)
+            self:ApplyCooldown(abilityId)
         end
-    end
-end
-
---- Clean up old corrupted cooldown groups from saved variables
-function SynergyTracker:CleanupCorruptedCooldownGroups()
-    local Settings = CombatInfo.SV.synergy
-
-    if not Settings.cooldownGroups then
-        Settings.cooldownGroups = {}
-        return
-    end
-
-    local oldCount = NonContiguousCount(Settings.cooldownGroups)
-    ZO_ClearTable(Settings.cooldownGroups)
-
-    if oldCount > 0 and LUIE.IsDevDebugEnabled() then
-        LUIE:Log("Debug", "Cleared %d old cooldown groups", oldCount)
     end
 end
 
@@ -735,77 +629,7 @@ end
 --- @param abilityId integer Synergy ability ID
 --- @return integer[] Group of synergy IDs that share cooldowns
 function SynergyTracker:GetSharedCooldownGroup(abilityId)
-    local hardcodedGroup = HARDCODED_SHARED_COOLDOWNS[abilityId]
-    if hardcodedGroup then
-        return hardcodedGroup
-    end
-    return { abilityId }
-end
-
---- Detect and apply shared cooldowns for activated synergy
---- @param activatedAbilityId integer Activated synergy ability ID
-function SynergyTracker:DetectSharedCooldowns(activatedAbilityId)
-    local Settings = CombatInfo.SV.synergy
-
-    if not Settings.showCooldowns then
-        return
-    end
-
-    local currentTime = GetGameTimeMilliseconds()
-    local cooldownDuration = GetAbilityCooldown(activatedAbilityId, "player")
-
-    if not cooldownDuration or cooldownDuration == 0 then
-        return
-    end
-
-    local sharedGroup = self:GetSharedCooldownGroup(activatedAbilityId)
-
-    -- Apply cooldown to all group members that don't already have it
-    for _, abilityId in ipairs(sharedGroup) do
-        local synergyData = Settings.detectedSynergies[abilityId]
-        if synergyData and not self.synergyCooldowns[abilityId] then
-            self.synergyCooldowns[abilityId] =
-            {
-                startTime = currentTime,
-                duration = cooldownDuration,
-                name = synergyData.name,
-                icon = synergyData.icon,
-                priority = Settings.priorityOverrides[abilityId] or 0,
-            }
-        end
-    end
-
-    self:UpdateDisplay()
-end
-
---- Apply immediate cooldown when synergy effect fades
---- @param abilityId integer Synergy ability ID
-function SynergyTracker:ApplyImmediateCooldown(abilityId)
-    local Settings = CombatInfo.SV.synergy
-    local currentTime = GetGameTimeMilliseconds()
-    local cooldownDuration = GetAbilityCooldown(abilityId, "player")
-
-    if not cooldownDuration or cooldownDuration == 0 then
-        return
-    end
-
-    local sharedGroup = self:GetSharedCooldownGroup(abilityId)
-
-    for _, groupAbilityId in ipairs(sharedGroup) do
-        local synergyData = Settings.detectedSynergies[groupAbilityId]
-        if synergyData and not Settings.blacklist[groupAbilityId] then
-            self.synergyCooldowns[groupAbilityId] =
-            {
-                startTime = currentTime,
-                duration = cooldownDuration,
-                name = synergyData.name,
-                icon = synergyData.icon,
-                priority = Settings.priorityOverrides[groupAbilityId] or 0,
-            }
-        end
-    end
-
-    self:UpdateDisplay()
+    return HARDCODED_SHARED_COOLDOWNS[abilityId] or { abilityId }
 end
 
 --- Apply saved position (center offset from GuiRoot)
@@ -823,7 +647,6 @@ function SynergyTracker:SetUnlocked(unlocked)
     local Settings = CombatInfo.SV.synergy
     Settings.unlocked = unlocked
 
-    -- When unlocked on console, add control to settings scene so preview is visible while addon settings are open
     if IsConsoleUI() then
         local settingsScene = sceneManager:GetScene("LibHarvensAddonSettingsScene")
         if self.settingsSceneFragment then
@@ -835,7 +658,6 @@ function SynergyTracker:SetUnlocked(unlocked)
         end
     end
 
-    -- PC version
     self.control:SetMovable(unlocked)
     self.control:SetMouseEnabled(unlocked)
     if self.bg then
@@ -845,11 +667,9 @@ function SynergyTracker:SetUnlocked(unlocked)
     if unlocked then
         self:ShowPreview()
     else
-        -- When locking, hide preview and return to normal display
         local currentScene = sceneManager:GetCurrentScene()
         local isInHUDScene = currentScene == sceneManager:GetScene(HUD_SCENE) or currentScene == sceneManager:GetScene(HUDUI_SCENE)
         if not isInHUDScene or currentScene:GetState() ~= SCENE_SHOWN then
-            -- If we're not in HUD/HUDUI scene, hide the control
             self.control:SetHidden(true)
         else
             self:UpdateDisplay()
@@ -857,9 +677,9 @@ function SynergyTracker:SetUnlocked(unlocked)
     end
 end
 
---- Show preview synergies for positioning
+--- Show preview synergies for positioning (shows PREVIEW_ROW_COUNT rows with placeholder data)
 function SynergyTracker:ShowPreview()
-    for i = 1, MAX_SYNERGY_SLOTS do
+    for i = 1, PREVIEW_ROW_COUNT do
         local control = self.synergyControls[i]
         if control then
             if control.icon then
@@ -879,14 +699,13 @@ function SynergyTracker:ShowPreview()
         end
     end
 
-    for i = 4, MAX_SYNERGY_SLOTS do
+    for i = PREVIEW_ROW_COUNT + 1, MAX_SYNERGY_SLOTS do
         local control = self.synergyControls[i]
         if control then
             control.row:SetHidden(true)
         end
     end
 
-    -- Force show when in unlock mode (even outside HUD scenes for positioning)
     self.control:SetHidden(false)
 end
 
@@ -969,7 +788,6 @@ end
 --- Factory function to create and initialize the tracker
 --- @return SynergyTracker|nil Tracker instance or nil if disabled
 function CombatInfo.InitializeSynergyTracker()
-    -- Return existing instance if already created (singleton pattern)
     if CombatInfo.SynergyTrackerInstance then
         return CombatInfo.SynergyTrackerInstance
     end
@@ -983,11 +801,7 @@ function CombatInfo.InitializeSynergyTracker()
         return
     end
 
-    -- Create the tracker instance
     local tracker = SynergyTracker:New()
-
-    -- Store globally for access from settings
     CombatInfo.SynergyTrackerInstance = tracker
-
     return tracker
 end

--- a/LuiExtended/pc/settings/CombatInfo.lua
+++ b/LuiExtended/pc/settings/CombatInfo.lua
@@ -15,7 +15,9 @@ local CombatInfo = LUIE.CombatInfo
 local ActionBar = LUIE.ActionBar
 local CrowdControlTracker = CombatInfo.CrowdControlTracker
 local AbilityAlerts = CombatInfo.AbilityAlerts
-local SynergyTracker = CombatInfo.SynergyTrackerInstance
+local function GetSynergyTracker()
+    return CombatInfo.SynergyTrackerInstance
+end
 local Block = CombatInfo.Block
 
 local type, pairs = type, pairs
@@ -3040,294 +3042,33 @@ function CombatInfo.CreateSettings()
     }
 
     -- Synergy Tracker
-    optionsDataCombatInfo[#optionsDataCombatInfo + 1] =
-    {
-        type = "submenu",
-        name = "Synergy Tracker",
-        controls =
-        {
-            {
-                -- Description
-                type = "description",
-                text = "Track and display multiple available synergies simultaneously. Set custom priorities and manage synergy preferences.",
-            },
-            {
-                -- Unlock UI
-                type = "checkbox",
-                name = "Unlock Synergy Display",
-                tooltip = "Unlock the synergy display to reposition it. Preview synergies will be shown while unlocked.",
-                getFunc = function ()
-                    return Settings.synergy.unlocked
-                end,
-                setFunc = function (value)
-                    local tracker = SynergyTracker
-                    if tracker then
-                        tracker:SetUnlocked(value)
-                    end
-                end,
-                width = "half",
-                default = false,
-                disabled = function ()
-                    return not Settings.synergy.enabled
-                end,
-            },
-            {
-                -- Reset Position
-                type = "button",
-                name = "Reset Position",
-                tooltip = "Reset the synergy display to default position.",
-                func = function ()
-                    local tracker = SynergyTracker
-                    if tracker then
-                        tracker:ResetPosition()
-                    end
-                end,
-                width = "half",
-                disabled = function ()
-                    return not Settings.synergy.enabled
-                end,
-            },
-            {
-                -- Enable Synergy Tracker
-                type = "checkbox",
-                name = "Enable Synergy Tracker",
-                tooltip = "Enable the synergy tracking system. This will monitor available synergies and allow you to set priority overrides. Changes require a UI reload (/reloadui).",
-                default = Defaults.synergy.enabled,
-                getFunc = function ()
-                    return Settings.synergy.enabled
-                end,
-                setFunc = function (value)
-                    Settings.synergy.enabled = value
-                end,
-                width = "full",
-                warning = "Requires UI reload (/reloadui) to take effect.",
-                requiresReload = true,
-            },
-            {
-                type = "header",
-                name = "Display Options",
-            },
-            {
-                -- Display Mode
-                type = "dropdown",
-                name = "Display Mode",
-                tooltip = "Single: Show only highest priority synergy (like default UI)\nMulti: Show all available synergies\nCompact: Show all synergies with short names",
-                choices = { "Single Synergy", "Multi-Synergy", "Compact Multi-Synergy" },
-                getFunc = function ()
-                    if Settings.synergy.displayMode == "single" then
-                        return "Single Synergy"
-                    elseif Settings.synergy.displayMode == "compact" then
-                        return "Compact Multi-Synergy"
-                    else
-                        return "Multi-Synergy"
-                    end
-                end,
-                setFunc = function (value)
-                    if value == "Single Synergy" then
-                        Settings.synergy.displayMode = "single"
-                    elseif value == "Compact Multi-Synergy" then
-                        Settings.synergy.displayMode = "compact"
-                    else
-                        Settings.synergy.displayMode = "multi"
-                    end
-                    local tracker = SynergyTracker
-                    if tracker then
-                        tracker:UpdateDisplay()
-                    end
-                end,
-                width = "full",
-                default = "Multi-Synergy",
-                disabled = function ()
-                    return not Settings.synergy.enabled
-                end,
-            },
-            {
-                -- Max Display
-                type = "slider",
-                name = zo_strformat("\t\t\t\t\t<<1>>", "Maximum Synergies to Display"),
-                tooltip = "Maximum number of synergies to show simultaneously (1-10). Includes both active and cooldown synergies.",
-                min = 1,
-                max = 10,
-                step = 1,
-                getFunc = function ()
-                    return Settings.synergy.maxDisplay
-                end,
-                setFunc = function (value)
-                    Settings.synergy.maxDisplay = value
-                    local tracker = SynergyTracker
-                    if tracker then
-                        tracker:UpdateDisplay()
-                    end
-                end,
-                width = "full",
-                default = Defaults.synergy.maxDisplay,
-                disabled = function ()
-                    return not Settings.synergy.enabled or Settings.synergy.displayMode == "single"
-                end,
-            },
-            {
-                -- Show Priority Numbers
-                type = "checkbox",
-                name = zo_strformat("\t\t\t\t\t<<1>>", "Show Priority Numbers"),
-                tooltip = "Display priority numbers next to each synergy.",
-                getFunc = function ()
-                    return Settings.synergy.showPriority
-                end,
-                setFunc = function (value)
-                    Settings.synergy.showPriority = value
-                    local tracker = SynergyTracker
-                    if tracker then
-                        tracker:UpdateDisplayOptions()
-                    end
-                end,
-                width = "full",
-                default = Defaults.synergy.showPriority,
-                disabled = function ()
-                    return not Settings.synergy.enabled
-                end,
-            },
-            {
-                -- Show Keybind Numbers
-                type = "checkbox",
-                name = zo_strformat("\t\t\t\t\t<<1>>", "Show Position Numbers"),
-                tooltip = "Display position numbers (1-5) next to each synergy to show its order in the list.",
-                getFunc = function ()
-                    return Settings.synergy.showKeybinds
-                end,
-                setFunc = function (value)
-                    Settings.synergy.showKeybinds = value
-                    local tracker = SynergyTracker
-                    if tracker then
-                        tracker:UpdateDisplayOptions()
-                    end
-                end,
-                width = "full",
-                default = Defaults.synergy.showKeybinds,
-                disabled = function ()
-                    return not Settings.synergy.enabled
-                end,
-            },
-            {
-                -- Play Sound
-                type = "checkbox",
-                name = zo_strformat("\t\t\t\t\t<<1>>", "Play Sound on New Synergy"),
-                tooltip = "Play a sound notification when a new synergy becomes available.",
-                getFunc = function ()
-                    return Settings.synergy.playSound
-                end,
-                setFunc = function (value)
-                    Settings.synergy.playSound = value
-                end,
-                width = "full",
-                default = Defaults.synergy.playSound,
-                disabled = function ()
-                    return not Settings.synergy.enabled
-                end,
-            },
-            {
-                -- Show Cooldowns
-                type = "checkbox",
-                name = zo_strformat("\t\t\t\t\t<<1>>", "Show Synergies on Cooldown"),
-                tooltip = "Display synergies that are currently on cooldown. The tracker automatically learns which synergies share cooldowns by detecting when multiple synergies go on cooldown together.",
-                getFunc = function ()
-                    return Settings.synergy.showCooldowns
-                end,
-                setFunc = function (value)
-                    Settings.synergy.showCooldowns = value
-                    local tracker = SynergyTracker
-                    if tracker then
-                        if not value then
-                            tracker.synergyCooldowns = {}
-                        end
-                        tracker:UpdateDisplay()
-                    end
-                end,
-                width = "full",
-                default = Defaults.synergy.showCooldowns,
-                disabled = function ()
-                    return not Settings.synergy.enabled or Settings.synergy.displayMode == "single"
-                end,
-            },
-            {
-                type = "header",
-                name = "Detected Synergies & Priority Overrides",
-            },
-            {
-                type = "description",
-                text = "Synergies detected during gameplay will appear below. Each synergy has a checkbox to blacklist (hide) it and a slider to set custom priority (0 = game default, 1-10 = higher priority).",
-            },
-            {
-                -- Clear All Overrides Button
-                type = "button",
-                name = "Clear All Priority Overrides",
-                tooltip = "Remove all custom priority overrides and reset to game defaults.",
-                func = function ()
-                    local tracker = SynergyTracker
-                    if tracker then
-                        tracker:ClearAllPriorityOverrides()
-                    end
-                end,
-                width = "half",
-                disabled = function ()
-                    return not Settings.synergy.enabled
-                end,
-            },
-            {
-                -- Clear Blacklist Button
-                type = "button",
-                name = "Clear Blacklist",
-                tooltip = "Remove all synergies from the blacklist.",
-                func = function ()
-                    Settings.synergy.blacklist = {}
-                    local tracker = SynergyTracker
-                    if tracker then
-                        tracker:RefreshActiveSynergies()
-                    end
-                    LUIE.PrintToChat("Blacklist cleared. Refresh settings to see changes.", true)
-                end,
-                width = "half",
-                disabled = function ()
-                    return not Settings.synergy.enabled
-                end,
-            },
-            {
-                -- Refresh Detected List Button
-                type = "button",
-                name = "Refresh List",
-                tooltip = "Refresh the list of detected synergies. Close and reopen settings to see updated list.",
-                func = function ()
-                    LUIE.PrintToChat("Refresh settings menu to see updated synergy list.", true)
-                end,
-                width = "half",
-                disabled = function ()
-                    return not Settings.synergy.enabled
-                end,
-            },
-        },
-    }
+    -- Forward-declare so the Refresh button closure can reference them before assignment
+    local synergySubmenuControls
+    local SYNERGY_STATIC_COUNT
+    local BuildSynergyDetectedControls
 
-    -- Dynamically add detected synergies to the settings menu
-    local tracker = SynergyTracker
-    local detectedList = tracker and tracker:GetDetectedSynergiesSorted() or {}
-    if #detectedList > 0 then
-        local synergySubmenu = optionsDataCombatInfo[#optionsDataCombatInfo]
-
-        for _, synergyData in ipairs(detectedList) do
+    -- Rebuilds the per-synergy controls from current detectedSynergies into synergySubmenuControls.
+    -- Truncates back to the static entries first so it is safe to call repeatedly.
+    BuildSynergyDetectedControls = function ()
+        while #synergySubmenuControls > SYNERGY_STATIC_COUNT do
+            table.remove(synergySubmenuControls)
+        end
+        local t = GetSynergyTracker()
+        local list = t and t:GetDetectedSynergiesSorted() or {}
+        for _, synergyData in ipairs(list) do
             local abilityId = synergyData.abilityId
-            local name = synergyData.name
+            local sName = synergyData.name
             local icon = synergyData.icon
             local timesSeen = synergyData.timesSeen
 
-            -- Synergy header with icon and name
-            table_insert(synergySubmenu.controls,
+            table_insert(synergySubmenuControls,
                          {
                              type = "description",
-                             text = zo_iconFormat(icon, 32, 32) .. " " .. zo_strformat("<<C:1>>", name) .. string_format(" |cAAAAAA(Seen: %d times)|r", timesSeen),
+                             text = zo_iconFormat(icon, 32, 32) .. " " .. zo_strformat("<<C:1>>", sName) .. string_format(" |cAAAAAA(Seen: %d times)|r", timesSeen),
                              width = "full",
                          })
 
-            -- Blacklist toggle
-            table_insert(synergySubmenu.controls,
+            table_insert(synergySubmenuControls,
                          {
                              type = "checkbox",
                              name = zo_strformat("\t\t\t\t\t<<1>>", "Blacklist (Hide)"),
@@ -3337,8 +3078,9 @@ function CombatInfo.CreateSettings()
                              end,
                              setFunc = function (value)
                                  Settings.synergy.blacklist[abilityId] = value or nil
-                                 if tracker then
-                                     tracker:RefreshActiveSynergies()
+                                 local tk = GetSynergyTracker()
+                                 if tk then
+                                     tk:RefreshActiveSynergies()
                                  end
                              end,
                              width = "full",
@@ -3348,12 +3090,11 @@ function CombatInfo.CreateSettings()
                              end,
                          })
 
-            -- Priority slider
-            table_insert(synergySubmenu.controls,
+            table_insert(synergySubmenuControls,
                          {
                              type = "slider",
                              name = zo_strformat("\t\t\t\t\t<<1>>", "Priority Override"),
-                             tooltip = string_format("Set priority for %s. Higher values = higher priority. 0 = game default.", name),
+                             tooltip = string_format("Set priority for %s. Higher values = higher priority. 0 = game default.", sName),
                              min = 0,
                              max = 10,
                              step = 1,
@@ -3376,14 +3117,274 @@ function CombatInfo.CreateSettings()
                              end,
                          })
 
-            -- Divider
-            table_insert(synergySubmenu.controls,
+            table_insert(synergySubmenuControls,
                          {
                              type = "divider",
                              width = "full",
                          })
         end
     end
+
+    synergySubmenuControls =
+    {
+        {
+            type = "description",
+            text = "Track and display multiple available synergies simultaneously. Set custom priorities and manage synergy preferences.",
+        },
+        {
+            type = "checkbox",
+            name = "Unlock Synergy Display",
+            tooltip = "Unlock the synergy display to reposition it. Preview synergies will be shown while unlocked.",
+            getFunc = function ()
+                return Settings.synergy.unlocked
+            end,
+            setFunc = function (value)
+                local tracker = GetSynergyTracker()
+                if tracker then
+                    tracker:SetUnlocked(value)
+                end
+            end,
+            width = "half",
+            default = false,
+            disabled = function ()
+                return not Settings.synergy.enabled
+            end,
+        },
+        {
+            type = "button",
+            name = "Reset Position",
+            tooltip = "Reset the synergy display to default position.",
+            func = function ()
+                local tracker = GetSynergyTracker()
+                if tracker then
+                    tracker:ResetPosition()
+                end
+            end,
+            width = "half",
+            disabled = function ()
+                return not Settings.synergy.enabled
+            end,
+        },
+        {
+            type = "checkbox",
+            name = "Enable Synergy Tracker",
+            tooltip = "Enable the synergy tracking system. This will monitor available synergies and allow you to set priority overrides. Changes require a UI reload (/reloadui).",
+            default = Defaults.synergy.enabled,
+            getFunc = function ()
+                return Settings.synergy.enabled
+            end,
+            setFunc = function (value)
+                Settings.synergy.enabled = value
+            end,
+            width = "full",
+            warning = "Requires UI reload (/reloadui) to take effect.",
+            requiresReload = true,
+        },
+        {
+            type = "header",
+            name = "Display Options",
+        },
+        {
+            type = "dropdown",
+            name = "Display Mode",
+            tooltip = "Single: Show only highest priority synergy (like default UI)\nMulti: Show all available synergies\nCompact: Show all synergies with short names",
+            choices = { "Single Synergy", "Multi-Synergy", "Compact Multi-Synergy" },
+            getFunc = function ()
+                if Settings.synergy.displayMode == "single" then
+                    return "Single Synergy"
+                elseif Settings.synergy.displayMode == "compact" then
+                    return "Compact Multi-Synergy"
+                else
+                    return "Multi-Synergy"
+                end
+            end,
+            setFunc = function (value)
+                if value == "Single Synergy" then
+                    Settings.synergy.displayMode = "single"
+                elseif value == "Compact Multi-Synergy" then
+                    Settings.synergy.displayMode = "compact"
+                else
+                    Settings.synergy.displayMode = "multi"
+                end
+                local tracker = GetSynergyTracker()
+                if tracker then
+                    tracker:UpdateDisplay()
+                end
+            end,
+            width = "full",
+            default = "Multi-Synergy",
+            disabled = function ()
+                return not Settings.synergy.enabled
+            end,
+        },
+        {
+            type = "slider",
+            name = zo_strformat("\t\t\t\t\t<<1>>", "Maximum Synergies to Display"),
+            tooltip = "Maximum number of synergies to show simultaneously (1-10). Includes both active and cooldown synergies.",
+            min = 1,
+            max = 10,
+            step = 1,
+            getFunc = function ()
+                return Settings.synergy.maxDisplay
+            end,
+            setFunc = function (value)
+                Settings.synergy.maxDisplay = value
+                local tracker = GetSynergyTracker()
+                if tracker then
+                    tracker:UpdateDisplay()
+                end
+            end,
+            width = "full",
+            default = Defaults.synergy.maxDisplay,
+            disabled = function ()
+                return not Settings.synergy.enabled or Settings.synergy.displayMode == "single"
+            end,
+        },
+        {
+            type = "checkbox",
+            name = zo_strformat("\t\t\t\t\t<<1>>", "Show Priority Numbers"),
+            tooltip = "Display priority numbers next to each synergy.",
+            getFunc = function ()
+                return Settings.synergy.showPriority
+            end,
+            setFunc = function (value)
+                Settings.synergy.showPriority = value
+                local tracker = GetSynergyTracker()
+                if tracker then
+                    tracker:UpdateDisplayOptions()
+                end
+            end,
+            width = "full",
+            default = Defaults.synergy.showPriority,
+            disabled = function ()
+                return not Settings.synergy.enabled
+            end,
+        },
+        {
+            type = "checkbox",
+            name = zo_strformat("\t\t\t\t\t<<1>>", "Show Position Numbers"),
+            tooltip = "Display position numbers (1-5) next to each synergy to show its order in the list.",
+            getFunc = function ()
+                return Settings.synergy.showKeybinds
+            end,
+            setFunc = function (value)
+                Settings.synergy.showKeybinds = value
+                local tracker = GetSynergyTracker()
+                if tracker then
+                    tracker:UpdateDisplayOptions()
+                end
+            end,
+            width = "full",
+            default = Defaults.synergy.showKeybinds,
+            disabled = function ()
+                return not Settings.synergy.enabled
+            end,
+        },
+        {
+            type = "checkbox",
+            name = zo_strformat("\t\t\t\t\t<<1>>", "Play Sound on New Synergy"),
+            tooltip = "Play a sound notification when a new synergy becomes available.",
+            getFunc = function ()
+                return Settings.synergy.playSound
+            end,
+            setFunc = function (value)
+                Settings.synergy.playSound = value
+            end,
+            width = "full",
+            default = Defaults.synergy.playSound,
+            disabled = function ()
+                return not Settings.synergy.enabled
+            end,
+        },
+        {
+            type = "checkbox",
+            name = zo_strformat("\t\t\t\t\t<<1>>", "Show Synergies on Cooldown"),
+            tooltip = "Display synergies that are currently on cooldown. The tracker automatically learns which synergies share cooldowns by detecting when multiple synergies go on cooldown together.",
+            getFunc = function ()
+                return Settings.synergy.showCooldowns
+            end,
+            setFunc = function (value)
+                Settings.synergy.showCooldowns = value
+                local tracker = GetSynergyTracker()
+                if tracker then
+                    if not value then
+                        tracker.synergyCooldowns = {}
+                    end
+                    tracker:UpdateDisplay()
+                end
+            end,
+            width = "full",
+            default = Defaults.synergy.showCooldowns,
+            disabled = function ()
+                return not Settings.synergy.enabled or Settings.synergy.displayMode == "single"
+            end,
+        },
+        {
+            type = "header",
+            name = "Detected Synergies & Priority Overrides",
+        },
+        {
+            type = "description",
+            text = "Synergies detected during gameplay will appear below. Each synergy has a checkbox to blacklist (hide) it and a slider to set custom priority (0 = game default, 1-10 = higher priority).",
+        },
+        {
+            type = "button",
+            name = "Clear All Priority Overrides",
+            tooltip = "Remove all custom priority overrides and reset to game defaults.",
+            func = function ()
+                local tracker = GetSynergyTracker()
+                if tracker then
+                    tracker:ClearAllPriorityOverrides()
+                end
+            end,
+            width = "half",
+            disabled = function ()
+                return not Settings.synergy.enabled
+            end,
+        },
+        {
+            type = "button",
+            name = "Clear Blacklist",
+            tooltip = "Remove all synergies from the blacklist.",
+            func = function ()
+                Settings.synergy.blacklist = {}
+                local tracker = GetSynergyTracker()
+                if tracker then
+                    tracker:RefreshActiveSynergies()
+                end
+                LUIE.PrintToChat("Blacklist cleared.", true)
+            end,
+            width = "half",
+            disabled = function ()
+                return not Settings.synergy.enabled
+            end,
+        },
+        {
+            type = "button",
+            name = "Refresh List",
+            tooltip = "Rebuild the detected synergy list from current session data.",
+            func = function ()
+                BuildSynergyDetectedControls()
+            end,
+            width = "half",
+            disabled = function ()
+                return not Settings.synergy.enabled
+            end,
+        },
+    }
+
+    -- Record static control count so BuildSynergyDetectedControls knows where to truncate
+    SYNERGY_STATIC_COUNT = #synergySubmenuControls
+
+    -- Populate detected synergies for the current session
+    BuildSynergyDetectedControls()
+
+    optionsDataCombatInfo[#optionsDataCombatInfo + 1] =
+    {
+        type = "submenu",
+        name = "Synergy Tracker",
+        controls = synergySubmenuControls,
+    }
 
     -- Block Indicator
     optionsDataCombatInfo[#optionsDataCombatInfo + 1] =

--- a/LuiExtended/shared/synergy.lua
+++ b/LuiExtended/shared/synergy.lua
@@ -9,28 +9,78 @@ local LUIE = LUIE
 local Data = LuiData.Data
 local Effects = Data.Effects
 
+
+-- Finds the abilityId of the synergy currently shown by GetCurrentSynergyInfo() by matching its
+-- name through GetSynergyInfoAtIndex. The list index order is not guaranteed to match priority
+-- order, so index 1 is not reliable; name-matching against the current synergy name is the only
+-- safe way to get the abilityId.
+local function GetCurrentSynergyAbilityId(currentName)
+    local numSynergies = GetNumberOfAvailableSynergies()
+    for i = 1, numSynergies do
+        local name, _, _, _, abilityId = GetSynergyInfoAtIndex(i)
+        if name == currentName then
+            return abilityId
+        end
+    end
+end
+
+-- ZO_Synergy:OnSynergyAbilityChanged only plays the sound when self.lastSynergyName ~= synergyName.
+-- Setting lastSynergyName to the current name before the method runs makes that check false,
+-- skipping PlaySound without touching any other base-game behavior.
+
+-- Hook synergy popup Icon/Name (to fix inconsistencies and add custom icons for some Quest/Encounter based Synergies)
 LUIE.HookSynergy = function ()
     if IsConsoleUI() then return end
-    -- Hook synergy popup Icon/Name (to fix inconsistencies and add custom icons for some Quest/Encounter based Synergies)
-    -- Use ZO_PostHook to modify after original function runs, preserving base game behavior
+
+
+    -- PreHook: suppress the base game's PlaySound for blacklisted synergies.
+    ---
+    --- @param self ZO_Synergy
+    ZO_PreHook(ZO_Synergy, "OnSynergyAbilityChanged", function (self)
+        local synergySettings = LUIE.CombatInfo and LUIE.CombatInfo.SV and LUIE.CombatInfo.SV.synergy
+        if synergySettings and synergySettings.enabled and next(synergySettings.blacklist) then
+            local hasSynergy, synergyName = GetCurrentSynergyInfo()
+            if hasSynergy then
+                local abilityId = GetCurrentSynergyAbilityId(synergyName)
+                if abilityId and synergySettings.blacklist[abilityId] then
+                    self.lastSynergyName = synergyName
+                end
+            end
+        end
+    end)
+
+    -- PostHook: Used to modify after original function runs, preserving base game behavior
+    ---
+    --- @param self ZO_Synergy
     ZO_PostHook(ZO_Synergy, "OnSynergyAbilityChanged", function (self)
-        -- Quick check: only process if synergy override table exists and has entries
+        local hasSynergy, synergyName = GetCurrentSynergyInfo()
+
+        -- Suppress the base game popup for blacklisted synergies.
+        -- Hide through SHARED_INFORMATION_AREA so the visibility state stays coherent;
+        -- the next OnSynergyAbilityChanged restores it if a non-blacklisted synergy takes over.
+        if hasSynergy then
+            local synergySettings = LUIE.CombatInfo and LUIE.CombatInfo.SV and LUIE.CombatInfo.SV.synergy
+            if synergySettings and synergySettings.enabled and next(synergySettings.blacklist) then
+                local abilityId = GetCurrentSynergyAbilityId(synergyName)
+                if abilityId and synergySettings.blacklist[abilityId] then
+                    SHARED_INFORMATION_AREA:SetHidden(self, true)
+                    return
+                end
+            end
+        end
+
+        -- Apply icon/name overrides for quest and encounter synergies
         if not Effects.SynergyNameOverride or not next(Effects.SynergyNameOverride) then
             return
         end
 
-        local hasSynergy, synergyName = GetCurrentSynergyInfo()
-
-        -- Only process if synergy is available and we have an override for it
         if hasSynergy and synergyName and Effects.SynergyNameOverride[synergyName] then
             local override = Effects.SynergyNameOverride[synergyName]
 
-            -- Apply icon override if present
             if override.icon then
                 self.icon:SetTexture(override.icon)
             end
 
-            -- Apply name override if present
             if override.name then
                 local overridePrompt = zo_strformat(SI_USE_SYNERGY, override.name)
                 self.action:SetText(overridePrompt)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches runtime combat UI/event handling and saved-variable migration for the synergy tracker, so regressions could affect synergy display, cooldowns, or popup suppression in combat.
> 
> **Overview**
> **Synergy tracking/UI is refactored and behavior is tightened.** `SynergyTracker.xml` is slimmed down by replacing 10 hardcoded rows with a single virtual row template, and `SynergyTracker.lua` now creates/anchors rows dynamically and handles `OnUpdate`/move persistence in Lua (removing the old XML static handlers).
> 
> Synergy cooldown/selection logic is simplified: cooldown state is applied via a new `ApplyCooldown` path with only the hardcoded shared-cooldown group, the obsolete saved var `cooldownGroups` is removed/migrated away, and *single* display mode now chooses the highest-priority available synergy by sorting instead of relying on `GetCurrentSynergyInfo()` ordering. The synergy popup hook is updated so blacklisted synergies also suppress the base-game popup/sound, and the settings submenu now rebuilds its per-synergy controls dynamically via a Refresh button (avoiding stale `SynergyTrackerInstance` references).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9980db54bbf4fcd6c5109e33f5eea5518083436. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->