### PR TITLE
Update BarHighlightOverride.lua to replace outdated ability IDs with …

### DIFF
--- a/LuiData/Effects/BarHighlight/BarHighlightOverride.lua
+++ b/LuiData/Effects/BarHighlight/BarHighlightOverride.lua
@@ -68,8 +68,9 @@ local barHighlightOverride =
     [32715] = { newId = 61814 },                        -- Ferocious Leap
 
     -- Earthen Heart
-    [133037] = { newId = 29032 },                      -- Stonefist
-    [133027] = { newId = 31816 },                      -- Stone Giant
+    [29032] = { newId = 134310 },                      -- Superheated Ward
+    [31816] = { newId = 134340 },                      -- Magma Fist
+    [31820] = { newId = 261754 },                      -- Volcanic Ward
     [29043] = { newId = 258658, showFakeAura = true }, -- Molten Weapons --> Major Sorcery
     [31874] = { newId = 258666, showFakeAura = true }, -- Igneous Weapons --> Major Sorcery
     [31888] = { newId = 258661, showFakeAura = true }, -- Molten Armaments


### PR DESCRIPTION
…new ones for Superheated Ward, Magma Fist, and Volcanic Ward, enhancing compatibility with recent game changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple data-table remapping of ability IDs; risk is limited to incorrect highlights if an ID is wrong, with no broader logic or security impact.
> 
> **Overview**
> Updates `BarHighlightOverride.lua` to **replace outdated Dragonknight Earthen Heart override entries** with current ability IDs, mapping `Superheated Ward`, `Magma Fist`, and `Volcanic Ward` to their new tracked effect IDs.
> 
> This effectively removes the old `Stonefist`/`Stone Giant` override keys and introduces new mappings so bar highlights continue to track the correct effects after recent game ID changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab3a7bcc8ca6153f9995ddc7b0cbb2670649e194. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->