### PR TITLE
chore: bump version to 7.2.0.2 and update font handling

### DIFF
--- a/LuiExtended/LuiExtended.addon
+++ b/LuiExtended/LuiExtended.addon
@@ -2,8 +2,8 @@
 ## Author: @dack_janiels[PC]
 ## LegacyAuthors: ArtOfShred, psypanda, Saenic & SpellBuilder
 ## APIVersion: 101049 101050
-## Version: 7.2.0.1
-## AddOnVersion: 7201
+## Version: 7.2.0.2
+## AddOnVersion: 7202
 ## Description: Provides UnitFrames, InfoPanel, Combat Text & Info, Buff & Debuff Tracking, Chat Announcements and Slash Commands.
 ## DependsOn: LuiMedia>=7131 LuiData>=7205
 ## PCDependsOn: LibAddonMenu-2.0>=41

--- a/LuiExtended/modules/ActionBar/ActionBar.lua
+++ b/LuiExtended/modules/ActionBar/ActionBar.lua
@@ -712,12 +712,13 @@ function ActionBar.Initialize(enabled)
 
     -- -----------------------------------------------------------------------------
     -- Migrate font styles if needed
-    if not LUIE.IsMigrationDone("actionbar_fontstyles") then
+    -- Migrate font styles (string/display/nil -> valid 0-7); run once per account
+    if not LUIE.IsMigrationDone("actionbar_fontstyles_v2") then
         ActionBar.SV.UltimateFontStyle = LUIE.MigrateFontStyle(ActionBar.SV.UltimateFontStyle)
         ActionBar.SV.BarFontStyle = LUIE.MigrateFontStyle(ActionBar.SV.BarFontStyle)
         ActionBar.SV.PotionTimerFontStyle = LUIE.MigrateFontStyle(ActionBar.SV.PotionTimerFontStyle)
         ActionBar.SV.CastBarFontStyle = LUIE.MigrateFontStyle(ActionBar.SV.CastBarFontStyle)
-        LUIE.MarkMigrationDone("actionbar_fontstyles")
+        LUIE.MarkMigrationDone("actionbar_fontstyles_v2")
     end
 
     -- -----------------------------------------------------------------------------

--- a/LuiExtended/modules/CombatInfo/CombatInfo.lua
+++ b/LuiExtended/modules/CombatInfo/CombatInfo.lua
@@ -138,12 +138,13 @@ function CombatInfo.Initialize(enabled)
         CombatInfo.SV = ZO_SavedVars:NewAccountWide(LUIE.SVName, LUIE.SVVer, "CombatInfo", CombatInfo.Defaults)
     end
 
-    if not LUIE.IsMigrationDone("combatinfo_fontstyles") then
+    -- Migrate font styles (string/display/nil -> valid 0-7); run once per account
+    if not LUIE.IsMigrationDone("combatinfo_fontstyles_v2") then
         CombatInfo.SV.CastBarFontStyle = LUIE.MigrateFontStyle(CombatInfo.SV.CastBarFontStyle)
         if CombatInfo.SV.alerts and CombatInfo.SV.alerts.toggles then
             CombatInfo.SV.alerts.toggles.alertFontStyle = LUIE.MigrateFontStyle(CombatInfo.SV.alerts.toggles.alertFontStyle)
         end
-        LUIE.MarkMigrationDone("combatinfo_fontstyles")
+        LUIE.MarkMigrationDone("combatinfo_fontstyles_v2")
     end
 
     if not enabled then

--- a/LuiExtended/modules/CombatText/CombatText.lua
+++ b/LuiExtended/modules/CombatText/CombatText.lua
@@ -257,9 +257,10 @@ function CombatText.Initialize(enabled)
     end
 
     -- Migrate old string-based font styles to numeric constants (run once)
-    if not LUIE.IsMigrationDone("combattext_fontstyles") then
+    -- Migrate font style (string/display/nil -> valid 0-7); run once per account
+    if not LUIE.IsMigrationDone("combattext_fontstyles_v2") then
         CombatText.SV.fontStyle = LUIE.MigrateFontStyle(CombatText.SV.fontStyle)
-        LUIE.MarkMigrationDone("combattext_fontstyles")
+        LUIE.MarkMigrationDone("combattext_fontstyles_v2")
     end
 
     -- Disable module if setting not toggled on

--- a/LuiExtended/modules/InfoPanel/InfoPanel.lua
+++ b/LuiExtended/modules/InfoPanel/InfoPanel.lua
@@ -375,9 +375,10 @@ function InfoPanel.Initialize(enabled)
     end
 
     -- Migrate old string-based font styles to numeric constants (run once)
-    if not LUIE.IsMigrationDone("infopanel_fontstyles") then
+    -- Migrate font style (string/display/nil -> valid 0-7); run once per account
+    if not LUIE.IsMigrationDone("infopanel_fontstyles_v2") then
         InfoPanel.SV.FontStyle = LUIE.MigrateFontStyle(InfoPanel.SV.FontStyle)
-        LUIE.MarkMigrationDone("infopanel_fontstyles")
+        LUIE.MarkMigrationDone("infopanel_fontstyles_v2")
     end
 
     -- Disable module if setting not toggled on

--- a/LuiExtended/modules/InfoPanel/InfoPanel.lua
+++ b/LuiExtended/modules/InfoPanel/InfoPanel.lua
@@ -411,7 +411,7 @@ function InfoPanel.Initialize(enabled)
     end
     local fontStyle = InfoPanel.SV.FontStyle
     local fontSize = (InfoPanel.SV.FontSize and InfoPanel.SV.FontSize > 0) and InfoPanel.SV.FontSize or 16
-    g_infoPanelFont = ZO_CreateFontString(fontName, fontSize, fontStyle)
+    g_infoPanelFont = LUIE.CreateFontString(fontName, fontSize, fontStyle)
 
     -- Top Row Controls
     uiLatency.control = LUIE_InfoPanel_TopRow_Latency

--- a/LuiExtended/modules/SpellCastBuffs/SpellCastBuffs.lua
+++ b/LuiExtended/modules/SpellCastBuffs/SpellCastBuffs.lua
@@ -254,10 +254,11 @@ function SpellCastBuffs.Initialize(enabled)
     end
 
     -- Migrate old string-based font styles to numeric constants (run once)
-    if not LUIE.IsMigrationDone("spellcastbuffs_fontstyles") then
+    -- Migrate font styles (string/display/nil -> valid 0-7); run once per account
+    if not LUIE.IsMigrationDone("spellcastbuffs_fontstyles_v2") then
         SpellCastBuffs.SV.BuffFontStyle = LUIE.MigrateFontStyle(SpellCastBuffs.SV.BuffFontStyle)
         SpellCastBuffs.SV.ProminentLabelFontStyle = LUIE.MigrateFontStyle(SpellCastBuffs.SV.ProminentLabelFontStyle)
-        LUIE.MarkMigrationDone("spellcastbuffs_fontstyles")
+        LUIE.MarkMigrationDone("spellcastbuffs_fontstyles_v2")
     end
 
     -- Correct read values

--- a/LuiExtended/modules/SpellCastBuffs/SpellCastBuffs.lua
+++ b/LuiExtended/modules/SpellCastBuffs/SpellCastBuffs.lua
@@ -1682,7 +1682,7 @@ function SpellCastBuffs.ApplyFont()
     end
     local fontStyle = SpellCastBuffs.SV.BuffFontStyle
     local fontSize = (SpellCastBuffs.SV.BuffFontSize and SpellCastBuffs.SV.BuffFontSize > 0) and SpellCastBuffs.SV.BuffFontSize or 17
-    SpellCastBuffs.buffsFont = ZO_CreateFontString(fontName, fontSize, fontStyle)
+    SpellCastBuffs.buffsFont = LUIE.CreateFontString(fontName, fontSize, fontStyle)
 
     -- Font Setup for Prominent Buffs & Debuffs
     local prominentName = LUIE.Fonts[SpellCastBuffs.SV.ProminentLabelFontFace]
@@ -1692,7 +1692,7 @@ function SpellCastBuffs.ApplyFont()
     end
     local prominentStyle = SpellCastBuffs.SV.ProminentLabelFontStyle
     local prominentSize = (SpellCastBuffs.SV.ProminentLabelFontSize and SpellCastBuffs.SV.ProminentLabelFontSize > 0) and SpellCastBuffs.SV.ProminentLabelFontSize or 17
-    SpellCastBuffs.prominentFont = ZO_CreateFontString(prominentName, prominentSize, prominentStyle)
+    SpellCastBuffs.prominentFont = LUIE.CreateFontString(prominentName, prominentSize, prominentStyle)
 
     local needs_reset = {}
     -- And reset sizes of already existing icons

--- a/LuiExtended/modules/UnitFrames/UnitFrames.lua
+++ b/LuiExtended/modules/UnitFrames/UnitFrames.lua
@@ -165,10 +165,11 @@ function UnitFrames.Initialize(enabled)
     end
 
     -- Migrate old string-based font styles to numeric constants (run once)
-    if not LUIE.IsMigrationDone("unitframes_fontstyles") then
+    -- Migrate font styles (string/display/nil -> valid 0-7); run once per account
+    if not LUIE.IsMigrationDone("unitframes_fontstyles_v2") then
         UnitFrames.SV.DefaultFontStyle = LUIE.MigrateFontStyle(UnitFrames.SV.DefaultFontStyle)
         UnitFrames.SV.CustomFontStyle = LUIE.MigrateFontStyle(UnitFrames.SV.CustomFontStyle)
-        LUIE.MarkMigrationDone("unitframes_fontstyles")
+        LUIE.MarkMigrationDone("unitframes_fontstyles_v2")
     end
 
     if UnitFrames.SV.DefaultOocTransparency < 0 or UnitFrames.SV.DefaultOocTransparency > 100 then

--- a/LuiExtended/src/Changelog.lua
+++ b/LuiExtended/src/Changelog.lua
@@ -12,6 +12,13 @@ local GetDisplayName = GetDisplayName
 -- -----------------------------------------------------------------------------
 local changelogMessages =
 {
+    -- Version Header 7.2.0.2
+    "|cFFA500LuiExtended Version 7.2.0.2|r",
+    "",
+    -- Fixed
+    "|cFFFF00Fix:|r",
+    "|t12:12:EsoUI/Art/Miscellaneous/bullet.dds|t Info Panel / font system: fixed crash \"Checking type on argument fontStyle failed in GetFontStyleString_lua\" when SavedVariables contained a display string (e.g. |cFFFFFFNormal|r) or invalid FontStyle. Migration and font creation now normalize values and use a safe default; Info Panel and SpellCastBuffs use the shared wrapper so only valid FontStyle integers (0–7) are passed to the game API.",
+    "",
     -- Version Header 7.2.0.1
     "|cFFA500LuiExtended Version 7.2.0.1|r",
     "",

--- a/LuiExtended/src/Functions.lua
+++ b/LuiExtended/src/Functions.lua
@@ -95,29 +95,44 @@ do
         ["|soft-shadow-thick"] = FONT_STYLE_SOFT_SHADOW_THICK,
     }
 
+    -- Default when value is missing, unknown, or out of range (FontStyle must be integer 0-7 per API)
+    local LUIE_FONT_STYLE_DEFAULT = FONT_STYLE_SOFT_SHADOW_THIN
+
     --- Creates a font string using ZOS's ZO_CreateFontString function
-    --- Supports both string-based and numeric font styles for backwards compatibility
+    --- Supports both string-based and numeric font styles for backwards compatibility.
+    --- Ensures the third argument is always a valid FontStyle (integer 0-7).
     --- @param faceName string Font face name
     --- @param size number Font size
     --- @param style string|number|nil Font style (string will be converted to constant)
     --- @return string Font string
     local function CreateFontString(faceName, size, style)
-        local styleConstant = style
-        -- Convert string styles to numeric constants if needed
-        if type(style) == "string" then
-            styleConstant = LUIE_FONT_STYLE_TO_CONSTANT[style]
+        local styleConstant = LUIE_FONT_STYLE_DEFAULT
+        if style == nil then
+            styleConstant = LUIE_FONT_STYLE_DEFAULT
+        elseif type(style) == "string" then
+            styleConstant = LUIE_FONT_STYLE_TO_CONSTANT[style] or LUIE_FONT_STYLE_DEFAULT
+        elseif type(style) == "number" and style >= 0 and style <= 7 then
+            styleConstant = style
         end
         return ZO_CreateFontString(faceName, size, styleConstant)
     end
 
-    --- Migrates old string-based font style to numeric constant
-    --- @param styleValue string|number Font style value
-    --- @return number Numeric font style constant
+    --- Migrates old string-based font style to numeric constant.
+    --- Returns a valid FontStyle (0-7); never returns nil.
+    --- @param styleValue string|number|nil Font style value from SV
+    --- @return number Numeric font style constant (0-7)
     local function MigrateFontStyle(styleValue)
-        if type(styleValue) == "string" then
-            return LUIE_FONT_STYLE_TO_CONSTANT[styleValue]
+        if styleValue == nil then
+            return LUIE_FONT_STYLE_DEFAULT
         end
-        return styleValue
+        if type(styleValue) == "string" then
+            local result = LUIE_FONT_STYLE_TO_CONSTANT[styleValue]
+            return result or LUIE_FONT_STYLE_DEFAULT
+        end
+        if type(styleValue) == "number" and styleValue >= 0 and styleValue <= 7 then
+            return styleValue
+        end
+        return LUIE_FONT_STYLE_DEFAULT
     end
 
     -- Font style choices for settings menus

--- a/LuiExtended/src/Functions.lua
+++ b/LuiExtended/src/Functions.lua
@@ -107,9 +107,7 @@ do
     --- @return string Font string
     local function CreateFontString(faceName, size, style)
         local styleConstant = LUIE_FONT_STYLE_DEFAULT
-        if style == nil then
-            styleConstant = LUIE_FONT_STYLE_DEFAULT
-        elseif type(style) == "string" then
+        if type(style) == "string" then
             styleConstant = LUIE_FONT_STYLE_TO_CONSTANT[style] or LUIE_FONT_STYLE_DEFAULT
         elseif type(style) == "number" and style >= 0 and style <= 7 then
             styleConstant = style

--- a/LuiExtended/src/LuiExtended.lua
+++ b/LuiExtended/src/LuiExtended.lua
@@ -28,8 +28,8 @@ local LUIE = LUIE
 -- -----------------------------------------------------------------------------
 LUIE.tag = "LUIE"
 LUIE.name = "LuiExtended"
-LUIE.version = "7.2.0.1"
-LUIE.addonVersion = 7201
+LUIE.version = "7.2.0.2"
+LUIE.addonVersion = 7202
 LUIE.author = "@dack_janiels[PC]"
 LUIE.legacyAuthors = "ArtOfShred, psypanda, Saenic & SpellBuilder"
 LUIE.website = "https://www.esoui.com/downloads/info818-LuiExtended.html"


### PR DESCRIPTION
- Updated version and addon version to 7.2.0.2 and 7202 respectively.
- Refactored font creation in InfoPanel and SpellCastBuffs to use a shared wrapper function, ensuring valid font styles are passed to the game API.
- Enhanced font style migration logic to handle missing or invalid values, providing a safe default.
- Updated changelog to reflect the changes and fixes related to font handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SavedVariables migrations across multiple modules and changes font-string creation, which could affect user UI settings if edge-case SV values are present, though the intent is to prevent crashes by normalizing inputs.
> 
> **Overview**
> Bumps addon metadata/version to `7.2.0.2` (`7202`) and adds a changelog entry for a font-style crash fix.
> 
> Hardens font style handling by updating `LUIE.CreateFontString`/`LUIE.MigrateFontStyle` to always produce a valid FontStyle (0–7) with a safe default, and updates module migrations to new `*_fontstyles_v2` keys so invalid/missing SV values are normalized once per account.
> 
> Switches `InfoPanel` and `SpellCastBuffs` font creation to use the shared `LUIE.CreateFontString` wrapper instead of calling `ZO_CreateFontString` directly, avoiding API errors when SVs contain display strings like `"Normal"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fea54386db489c71404b615ae0339ded5106cc9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->