### PR TITLE
feat: add block indicator shader option to CombatInfo settings

### DIFF
--- a/LuiExtended/console/settings/CombatInfo.lua
+++ b/LuiExtended/console/settings/CombatInfo.lua
@@ -3660,6 +3660,23 @@ function CombatInfo.CreateConsoleSettings()
                 return not Settings.block.enabled
             end,
         }
+        settings[#settings + 1] =
+        {
+            type = LHAS.ST_CHECKBOX,
+            label = GetString(LUIE_STRING_LAM_CI_BLOCK_USE_SHADER),
+            tooltip = GetString(LUIE_STRING_LAM_CI_BLOCK_USE_SHADER_TP),
+            getFunction = function ()
+                return CombatInfo.SV.block.useBlockIndicatorShader ~= false
+            end,
+            setFunction = function (value)
+                CombatInfo.SV.block.useBlockIndicatorShader = value
+                Block.ApplyBlockIndicatorShader()
+            end,
+            default = Defaults.block.useBlockIndicatorShader,
+            disable = function ()
+                return not Settings.block.enabled
+            end,
+        }
         local gwBlock = GuiRoot:GetWidth()
         local ghBlock = GuiRoot:GetHeight()
         settings[#settings + 1] =

--- a/LuiExtended/lang/settings/de.lua
+++ b/LuiExtended/lang/settings/de.lua
@@ -1295,6 +1295,10 @@ local strings =
     LUIE_STRING_LAM_CI_ENEMY_MARKER = "Gegner-Markierungen anzeigen",
     LUIE_STRING_LAM_CI_ENEMY_MARKER_TP = "Zeigt einen roten Pfeil über dem Kopf von Gegnern an, mit denen du dich im Kampf befindest.",
     LUIE_STRING_LAM_CI_ENEMY_MARKER_SIZE = "Gegner-Markierungsgröße",
+
+    -- CI Block Indicator
+    LUIE_STRING_LAM_CI_BLOCK_USE_SHADER = "Block-Indikator-Shader-Effekt verwenden",
+    LUIE_STRING_LAM_CI_BLOCK_USE_SHADER_TP = "Wendet einen Kaustik-Shader auf den Block-Indikator an. Deaktivieren, wenn das Symbol mit der Zeit verblasst.",
     LUIE_STRING_LAM_CI_HEADER_POTION = "Schnellzugriff-Abklingzeit-Timer-Optionen",
     LUIE_STRING_LAM_CI_POTION = "Schnellzugriff-Abklingzeit-Timer anzeigen",
     LUIE_STRING_LAM_CI_POTION_TP = "Zeigt einen Abklingzeit-Timer für Tränke und andere Schnellzugriff-Gegenstände an.",

--- a/LuiExtended/lang/settings/default.lua
+++ b/LuiExtended/lang/settings/default.lua
@@ -1385,6 +1385,10 @@ local strings =
     LUIE_STRING_LAM_CI_ENEMY_MARKER_TP = "Display a red arrow over the head of enemies you are currently in combat with.",
     LUIE_STRING_LAM_CI_ENEMY_MARKER_SIZE = "Enemy Marker Size",
 
+    -- CI Block Indicator
+    LUIE_STRING_LAM_CI_BLOCK_USE_SHADER = "Use block indicator shader effect",
+    LUIE_STRING_LAM_CI_BLOCK_USE_SHADER_TP = "Apply caustic shader to the block indicator. Disable if the icon fades out over time.",
+
     -- CI CCT
     LUIE_STRING_LAM_CI_CCT_HEADER = "Crowd Control Tracker",
     LUIE_STRING_LAM_CI_CCT_DESCRIPTION = "Display an animated icon when you are under the effects of crowd control. The options below allow you to customize the color, sound, and naming method for the alerts displayed. Additionally you can display alerts when standing in the radius of damaging area of effect abilities, with the option to enable/disable various categories with different sounds.",

--- a/LuiExtended/lang/settings/fr.lua
+++ b/LuiExtended/lang/settings/fr.lua
@@ -1304,6 +1304,10 @@ local strings =
     LUIE_STRING_LAM_CI_ENEMY_MARKER = "Show Enemy Markers",
     LUIE_STRING_LAM_CI_ENEMY_MARKER_TP = "Display a red arrow over the head of enemies you are currently in combat with.",
     LUIE_STRING_LAM_CI_ENEMY_MARKER_SIZE = "Enemy Marker Size",
+
+    -- CI Block Indicator
+    LUIE_STRING_LAM_CI_BLOCK_USE_SHADER = "Use block indicator shader effect",
+    LUIE_STRING_LAM_CI_BLOCK_USE_SHADER_TP = "Apply caustic shader to the block indicator. Disable if the icon fades out over time.",
     LUIE_STRING_LAM_CI_HEADER_POTION = "Quickslot Cooldown Timer Options",
     LUIE_STRING_LAM_CI_POTION = "Display Quickslot Cooldown Timer",
     LUIE_STRING_LAM_CI_POTION_TP = "Display a cooldown timer for potions and other quickslot items.",

--- a/LuiExtended/lang/settings/ru.lua
+++ b/LuiExtended/lang/settings/ru.lua
@@ -1304,6 +1304,10 @@ local strings =
     LUIE_STRING_LAM_CI_ENEMY_MARKER = "Show Enemy Markers",
     LUIE_STRING_LAM_CI_ENEMY_MARKER_TP = "Display a red arrow over the head of enemies you are currently in combat with.",
     LUIE_STRING_LAM_CI_ENEMY_MARKER_SIZE = "Enemy Marker Size",
+
+    -- CI Block Indicator
+    LUIE_STRING_LAM_CI_BLOCK_USE_SHADER = "Use block indicator shader effect",
+    LUIE_STRING_LAM_CI_BLOCK_USE_SHADER_TP = "Apply caustic shader to the block indicator. Disable if the icon fades out over time.",
     LUIE_STRING_LAM_CI_HEADER_POTION = "Перезарядка быстрой ячейки",
     LUIE_STRING_LAM_CI_POTION = "Перезарядка быстрой ячейки",
     LUIE_STRING_LAM_CI_POTION_TP = "Показывает таймер перезарядки для зелий и прочих предметов в ячейке быстрого доступа.",

--- a/LuiExtended/lang/settings/zh.lua
+++ b/LuiExtended/lang/settings/zh.lua
@@ -1307,6 +1307,10 @@ local strings =
     LUIE_STRING_LAM_CI_ENEMY_MARKER = "显示敌人标记",
     LUIE_STRING_LAM_CI_ENEMY_MARKER_TP = "在你当前战斗中的敌人头上显示一个红色箭头。",
     LUIE_STRING_LAM_CI_ENEMY_MARKER_SIZE = "敌人标记大小",
+
+    -- CI Block Indicator
+    LUIE_STRING_LAM_CI_BLOCK_USE_SHADER = "使用格挡指示器着色器效果",
+    LUIE_STRING_LAM_CI_BLOCK_USE_SHADER_TP = "对格挡指示器应用焦散着色器。若图标随时间逐渐变淡可关闭此项。",
     LUIE_STRING_LAM_CI_HEADER_POTION = "快速槽冷却计时器选项",
     LUIE_STRING_LAM_CI_POTION = "显示快速槽冷却计时器",
     LUIE_STRING_LAM_CI_POTION_TP = "为药水和其他快速槽物品显示冷却计时器。",

--- a/LuiExtended/modules/CombatInfo/Block.lua
+++ b/LuiExtended/modules/CombatInfo/Block.lua
@@ -220,7 +220,8 @@ end
 -- ---------------------------------------------------------------------------
 
 function Block.OnBlockUpdate()
-    local isBlocking = IsBlockActive()
+    local isSprinting = IsPlayerMoving() and IsShiftKeyDown()
+    local isBlocking = IsBlockActive() and not isSprinting
     local inCombat = IsUnitInCombat("player")
     local staminaRegen = GetPlayerStat(inCombat and STAT_STAMINA_REGEN_COMBAT or STAT_STAMINA_REGEN_IDLE, STAT_BONUS_OPTION_APPLY_BONUS)
     local magickaRegen = GetPlayerStat(inCombat and STAT_MAGICKA_REGEN_COMBAT or STAT_MAGICKA_REGEN_IDLE, STAT_BONUS_OPTION_APPLY_BONUS)

--- a/LuiExtended/modules/CombatInfo/Block.lua
+++ b/LuiExtended/modules/CombatInfo/Block.lua
@@ -220,8 +220,7 @@ end
 -- ---------------------------------------------------------------------------
 
 function Block.OnBlockUpdate()
-    local isSprinting = IsPlayerMoving() and IsShiftKeyDown()
-    local isBlocking = IsBlockActive() and not isSprinting
+    local isBlocking = IsBlockActive()
     local inCombat = IsUnitInCombat("player")
     local staminaRegen = GetPlayerStat(inCombat and STAT_STAMINA_REGEN_COMBAT or STAT_STAMINA_REGEN_IDLE, STAT_BONUS_OPTION_APPLY_BONUS)
     local magickaRegen = GetPlayerStat(inCombat and STAT_MAGICKA_REGEN_COMBAT or STAT_MAGICKA_REGEN_IDLE, STAT_BONUS_OPTION_APPLY_BONUS)
@@ -234,6 +233,10 @@ function Block.OnBlockUpdate()
     Block.blockIndicatorTexture:SetHidden(bothRegen or not isBlocking)
 
     local sv = CombatInfo.SV.block
+    -- When indicator is visible and shader is disabled, re-apply NONE each update so the setting reliably takes effect.
+    if not (bothRegen or not isBlocking) and sv.useBlockIndicatorShader == false then
+        Block.blockIndicatorTexture:SetShaderEffectType(SHADER_EFFECT_TYPE_NONE)
+    end
     if sv.colorShieldByResource then
         Block.blockIndicatorTexture:SetColor(0, staminaRegen > 0 and 0.5 or 1, magickaRegen > 0 and 0 or 1, 1)
     else
@@ -392,6 +395,19 @@ function Block.ApplyBlockShieldTexture()
     Block.blockIndicatorTexture:SetColor(1, 1, 1, 1)
 end
 
+--- Applies block indicator shader effect from settings (caustic vs none).
+function Block.ApplyBlockIndicatorShader()
+    if not Block.blockIndicatorTexture then
+        return
+    end
+    local useShader = CombatInfo.SV.block.useBlockIndicatorShader ~= false
+    Block.blockIndicatorTexture:SetShaderEffectType(useShader and SHADER_EFFECT_TYPE_CAUSTIC or SHADER_EFFECT_TYPE_NONE)
+    -- Re-apply texture so the shader change is picked up by the engine (avoids stale/cached effect).
+    local sv = CombatInfo.SV.block
+    local useGrey = sv.colorShieldByResource
+    Block.blockIndicatorTexture:SetTexture(useGrey and BLOCK_SHIELD_GREY_MEDIA or BLOCK_SHIELD_MEDIA)
+end
+
 --- Applies saved Bloodlord's Embrace window position from SV
 function Block.ApplyBloodlordEmbracePosition()
     if not Block.bloodlordWindow then
@@ -448,7 +464,11 @@ local function CreateBlockIndicatorWindow()
     texture:SetHidden(true)
     texture:SetBlendMode(TEX_BLEND_MODE_ADD)
     texture:SetPixelRoundingEnabled(true)
-    texture:SetShaderEffectType(SHADER_EFFECT_TYPE_CAUSTIC)
+    if CombatInfo.SV.block.useBlockIndicatorShader ~= false then
+        texture:SetShaderEffectType(SHADER_EFFECT_TYPE_CAUSTIC)
+    else
+        texture:SetShaderEffectType(SHADER_EFFECT_TYPE_NONE)
+    end
     Block.blockIndicatorTexture = texture
     Block.ApplyBlockShieldTexture()
 

--- a/LuiExtended/modules/CombatInfo/Namespace.lua
+++ b/LuiExtended/modules/CombatInfo/Namespace.lua
@@ -246,6 +246,7 @@ CombatInfo.Defaults =
         updateIntervalMs = 10,
         showRemainingBlocks = false,
         colorShieldByResource = false,
+        useBlockIndicatorShader = true,
         blockIndicatorFontFace = "LUIE Default Font",
         blockIndicatorFontStyle = FONT_STYLE_SOFT_SHADOW_THICK,
         blockIndicatorFontSize = 18,

--- a/LuiExtended/pc/settings/CombatInfo.lua
+++ b/LuiExtended/pc/settings/CombatInfo.lua
@@ -3534,6 +3534,23 @@ function CombatInfo.CreateSettings()
                 end,
             },
             {
+                type = "checkbox",
+                name = GetString(LUIE_STRING_LAM_CI_BLOCK_USE_SHADER),
+                tooltip = GetString(LUIE_STRING_LAM_CI_BLOCK_USE_SHADER_TP),
+                getFunc = function ()
+                    return CombatInfo.SV.block.useBlockIndicatorShader ~= false
+                end,
+                setFunc = function (value)
+                    CombatInfo.SV.block.useBlockIndicatorShader = value
+                    Block.ApplyBlockIndicatorShader()
+                end,
+                default = Defaults.block.useBlockIndicatorShader,
+                width = "full",
+                disabled = function ()
+                    return not Settings.block.enabled
+                end,
+            },
+            {
                 type = "dropdown",
                 name = "Bloodlord Embrace Font Face",
                 tooltip = "Font used for Bloodlord's Embrace tracker text.",


### PR DESCRIPTION
- Introduced a new checkbox setting to enable or disable the use of a caustic shader effect for the block indicator.
- Updated localization strings in multiple languages to support the new setting.
- Enhanced the block update logic to ensure the shader effect is applied correctly based on user preferences.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/settings change that only affects the block indicator’s rendering; main risk is visual regressions or performance impact from reapplying shader/texture during updates.
> 
> **Overview**
> Adds a new `useBlockIndicatorShader` saved setting (default on) and exposes it as a checkbox in both PC and console CombatInfo settings to enable/disable the block indicator’s caustic shader effect.
> 
> Updates `CombatInfo/Block.lua` to initialize the indicator with the chosen shader, provide `Block.ApplyBlockIndicatorShader()`, and ensure the shader/texture state is reapplied so toggling (and the “icon fades over time” workaround) takes effect immediately. Localization strings are added across supported languages for the new option.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 321857d306310f2b72ed41098825ab4b50129277. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->