### PR TITLE
Gamepad character sheet

### DIFF
--- a/.meta/eso_api_patchnotes/APIPatchNotesP49_2.txt
+++ b/.meta/eso_api_patchnotes/APIPatchNotesP49_2.txt
@@ -1,0 +1,128 @@
+******************
+***Enums Added ***
+******************
+
+h5. PlatformStoreIconLocation
+* PLATFORM_STORE_ICON_LOCATION_LOWER_CENTER
+* PLATFORM_STORE_ICON_LOCATION_LOWER_LEFT
+* PLATFORM_STORE_ICON_LOCATION_LOWER_RIGHT
+
+* CURRENCY_CHANGE_REASON_EVENT_TICKET_TO_TRADE_BARS_CONVERSION
+
+* RESPEC_RESULT_DISALLOWED_IN_ACTIVITY
+
+* ADVENTURE_ZONE_FACTION_GLITTERING_GOAD
+
+h5. TamrielTomePurchaseResult
+* TAMRIEL_TOME_PURCHASE_RESULT_ALREADY_OWNED
+* TAMRIEL_TOME_PURCHASE_RESULT_INVALID
+* TAMRIEL_TOME_PURCHASE_RESULT_NOT_ENOUGH_CURRENCY
+* TAMRIEL_TOME_PURCHASE_RESULT_SUCCESS
+* TAMRIEL_TOME_PURCHASE_RESULT_TIMED_OUT
+
+* DIRECT_PURCHASE_PURCHASE_SKU_RESULT_CARD_DECLINED
+* DIRECT_PURCHASE_PURCHASE_SKU_RESULT_INVALID_PAYMENT_INFO
+* DIRECT_PURCHASE_PURCHASE_SKU_RESULT_TIMED_OUT
+
+
+
+********************
+***Enums Removed ***
+********************
+
+* ADVENTURE_ZONE_FACTION_GLITTERING_GLOAD
+
+
+
+********************
+***Globals Added ***
+********************
+
+* RESPEC_CAST_TIME_MS
+
+
+
+**********************
+***Functions Added ***
+**********************
+
+* GetTomePointGainBonusPercentage()
+** _Returns:_ *integer* _bonusPercentage_
+
+
+* GetTamrielTomePremiumPlusBonusRewardInfo(*integer* _tamrielTomeId_)
+** _Returns:_ *integer* _rewardId_, *integer* _rewardQuantity_
+
+
+* GetTamrielTomePremiumPlusRewardDescription(*integer* _tamrielTomeId_)
+** _Returns:_ *string* _description_
+
+
+* GetCostToProgressToNextTier(*integer* _rewardTrackId_, *luaindex* _tierIndex_)
+** _Returns:_ *integer* _costToProgress_
+
+
+* HasInfinitelyRepeatableTierForRewardTrack(*integer* _rewardTrackId_)
+** _Returns:_ *bool* _hasInfinitelyRepeatableTier_
+
+
+* GetInfinitelyRepeatableTierForRewardTrack(*integer* _rewardTrackId_)
+** _Returns:_ *luaindex* _infinitelyRepeatableTier_
+
+
+* GetHighestTierPossibleForRewardTrack(*integer* _rewardTrackId_)
+** _Returns:_ *integer* _numTiers_
+
+
+* IsDirectPurchaseEnabled()
+** _Returns:_ *bool* _isEnabled_
+
+
+* GetAdventureZoneEventLocationStartTimestampMs(*luaindex* _locationIndex_)
+** _Returns:_ *integer53* _startTimestamp_
+
+
+* GetSkuDisplayName(*integer* _skuDefId_)
+** _Returns:_ *string* _displayName_
+
+
+* GetSkuPricingInfoFormatted(*integer* _skuDefId_)
+** _Returns:_ *string* _currentPrice_, *string* _basePrice_
+
+
+
+************************
+***Functions Removed ***
+************************
+
+* GetAdventureZoneEventLocationTimeLeftToStartMs(*luaindex* _locationIndex_)
+** _Returns:_ *integer* _timeLeftToStartMs_
+
+
+
+************************
+***Functions Changed ***
+************************
+
+Added _ignoreRateLimit_, made private
+* QuerySkuCatalog *private* (*bool* _ignoreRateLimit_)
+** _Returns:_ *integer* _queryId_
+
+
+
+********************
+*** Events Added ***
+********************
+
+* EVENT_ADVENTURE_ZONE_WORLD_EVENT_INIT
+
+* EVENT_ADVENTURE_ZONE_WORLD_EVENT_STARTS_SOON
+
+
+
+**********************
+*** Events Changed ***
+**********************
+
+Added _skuId_
+* EVENT_DIRECT_PURCHASE_PURCHASE_SKU_RESULT (*integer* _skuId_, *[DirectPurchasePurchaseSkuResult|#DirectPurchasePurchaseSkuResult]* _result_)

--- a/LuiExtended/gamepad/skills.lua
+++ b/LuiExtended/gamepad/skills.lua
@@ -24,12 +24,18 @@ LUIE.HookGamePadStats = function ()
         UPCOMING_LEVEL_UP_REWARDS = 7,
         ADVANCED_ATTRIBUTES = 8,
         MUNDUS = 9,
+        GUILD = 10,
     }
 
 
 
     function ZO_GamepadStats:RefreshMainList()
         if self.currentTitleDropdown and self.currentTitleDropdown:IsDropdownVisible() then
+            self.refreshMainListOnDropdownClose = true
+            return
+        end
+
+        if self.currentGuildDropdown and self.currentGuildDropdown:IsDropdownVisible() then
             self.refreshMainListOnDropdownClose = true
             return
         end
@@ -137,6 +143,9 @@ LUIE.HookGamePadStats = function ()
         -- Character Info
         self.mainList:AddEntryWithHeader("ZO_GamepadMenuEntryTemplate", self.advancedStatsEntry)
         self.mainList:AddEntry("ZO_GamepadMenuEntryTemplate", self.characterEntry)
+
+        -- Guild (tabard)
+        self.mainList:AddEntryWithHeader("ZO_GamepadStatGuildRow", self.guildEntry)
 
         -- Active Effects--
         self.numActiveEffects = 0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/list-building change plus API patch notes; main impact is potential nil/undefined `guildEntry`/dropdown wiring or list template mismatch in the gamepad stats screen.
> 
> **Overview**
> Updates the gamepad character sheet list refresh to support a new **Guild (tabard)** section: introduces a `GUILD` display mode, blocks list refresh while a guild dropdown is open, and inserts a `ZO_GamepadStatGuildRow` entry into the main list.
> 
> Adds new `APIPatchNotesP49_2.txt` documenting newly added/removed ESO API enums, globals, functions, and events for patch P49.2.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a59b14d7b6fe7b62152abf57d53021587470ec36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->