### PR TITLE
refactor: update player-to-player interaction handling for console an…

### DIFF
--- a/LuiExtended/modules/ChatAnnouncements/ChatAnnouncementsPlayerToPlayerHooks.lua
+++ b/LuiExtended/modules/ChatAnnouncements/ChatAnnouncementsPlayerToPlayerHooks.lua
@@ -172,7 +172,7 @@ local GAMEPAD_INTERACT_ICONS =
     },
 }
 
-local ALERT_IGNORED_STRING = IsConsoleUI() and SI_PLAYER_TO_PLAYER_BLOCKED or SI_PLAYER_TO_PLAYER_IGNORED
+local ALERT_IGNORED_STRING = ZO_IsConsoleOrGameCoreUI() and SI_PLAYER_TO_PLAYER_BLOCKED or SI_PLAYER_TO_PLAYER_IGNORED
 
 -- Custom alert helpers
 local function AlertIgnored(customStringId)
@@ -218,6 +218,8 @@ end
 
 -- HOOK PLAYER_TO_PLAYER Group Notifications to edit Ignore alert
 function ChatAnnouncements.PlayerToPlayerHook()
+    local originalShowPlayerInteractMenu = ZO_PlayerToPlayer.ShowPlayerInteractMenu
+
     function ZO_PlayerToPlayer:AddMenuEntry(text, icons, enabled, selectedFunction, errorReason)
         local normalIcon = enabled and icons.enabledNormal or icons.disabledNormal
         local selectedIcon = enabled and icons.enabledSelected or icons.disabledSelected
@@ -225,6 +227,13 @@ function ChatAnnouncements.PlayerToPlayerHook()
     end
 
     function ZO_PlayerToPlayer:ShowPlayerInteractMenu(isIgnored)
+        -- On console/GameCore, building the menu from addon code taints the callstack so
+        -- the Gamer Card option hits private APIs. Delegate to ZOS so the menu is built
+        -- in trusted context and Gamer Card works.
+        if ZO_IsConsoleOrGameCoreUI() then
+            return originalShowPlayerInteractMenu(self, isIgnored)
+        end
+
         local currentTargetCharacterName = self.currentTargetCharacterName
         local currentTargetCharacterNameRaw = self.currentTargetCharacterNameRaw
         local currentTargetDisplayName = self.currentTargetDisplayName
@@ -240,17 +249,12 @@ function ChatAnnouncements.PlayerToPlayerHook()
 
         self:GetRadialMenu():Clear()
 
-        -- Gamecard--
-        if IsConsoleUI() then
-            self:AddShowGamerCard(currentTargetDisplayName, currentTargetCharacterName)
-        end
-
         -- Whisper
         if IsChatSystemAvailableForCurrentPlatform() then
-            local nameToUse = primaryNameInternal
+            local nameToUse = ZO_IsConsoleOrGameCoreUI() and currentTargetDisplayName or primaryNameInternal
             local function WhisperOption()
                 -- On console, call StartTextEntry directly with dontShowHUDWindow to avoid SetSetting security error
-                if IsConsoleUI() then
+                if ZO_IsConsoleOrGameCoreUI() then
                     local chatSystem = ZO_GetChatSystem()
                     if chatSystem then
                         chatSystem:StartTextEntry(nil, CHAT_CHANNEL_WHISPER, nameToUse, true)
@@ -302,7 +306,7 @@ function ChatAnnouncements.PlayerToPlayerHook()
             self:AddMenuEntry(GetString(SI_PLAYER_TO_PLAYER_ADD_FRIEND), platformIcons[SI_PLAYER_TO_PLAYER_ADD_FRIEND], DISABLED, AlreadyFriendsWarning)
         else
             local function RequestFriendOption()
-                if IsConsoleUI() then
+                if ZO_IsConsoleOrGameCoreUI() then
                     ZO_ShowConsoleAddFriendDialog(currentTargetCharacterName)
                 else
                     RequestFriend(currentTargetDisplayName)
@@ -361,7 +365,7 @@ function ChatAnnouncements.PlayerToPlayerHook()
             local function DuelInviteOption()
                 ChallengeTargetToDuel(currentTargetCharacterName)
             end
-            local isEnabled = ENABLED_IF_NOT_IGNORED and isRestrictedCommunicationPermitted
+            local isEnabled = ENABLED_IF_NOT_IGNORED and (not ZO_IsConsoleOrGameCoreUI() or not IsCommunicationRestricted()) and isRestrictedCommunicationPermitted
             self:AddMenuEntry(GetString(SI_PLAYER_TO_PLAYER_INVITE_DUEL), platformIcons[SI_PLAYER_TO_PLAYER_INVITE_DUEL], isEnabled, isEnabled and DuelInviteOption or disabledOption)
         end
 
@@ -392,7 +396,7 @@ function ChatAnnouncements.PlayerToPlayerHook()
                 end
                 PlaySound(SOUNDS.GENERAL_ALERT_ERROR)
             end
-            local isEnabled = ENABLED_IF_NOT_IGNORED and not ZO_IsTributeLocked() and isRestrictedCommunicationPermitted
+            local isEnabled = ENABLED_IF_NOT_IGNORED and not ZO_IsTributeLocked() and (not ZO_IsConsoleOrGameCoreUI() or not IsCommunicationRestricted()) and isRestrictedCommunicationPermitted
             local entryFunction
             if isEnabled then
                 entryFunction = TributeInviteOption
@@ -408,7 +412,7 @@ function ChatAnnouncements.PlayerToPlayerHook()
         local function TradeInviteOption()
             TRADE_WINDOW:InitiateTrade(primaryNameInternal)
         end
-        local isEnabled = ENABLED_IF_NOT_IGNORED and isRestrictedCommunicationPermitted
+        local isEnabled = ENABLED_IF_NOT_IGNORED and (not ZO_IsConsoleOrGameCoreUI() or not IsCommunicationRestricted()) and isRestrictedCommunicationPermitted
         local tradeInviteFunction = isEnabled and TradeInviteOption or disabledOption
         self:AddMenuEntry(GetString(SI_PLAYER_TO_PLAYER_INVITE_TRADE), platformIcons[SI_PLAYER_TO_PLAYER_INVITE_TRADE], isEnabled, tradeInviteFunction)
 
@@ -424,10 +428,7 @@ function ChatAnnouncements.PlayerToPlayerHook()
         end
     end
 
-    function ZO_PlayerToPlayer:AddShowGamerCard(targetDisplayName, targetCharacterName)
-        self:GetRadialMenu():AddEntry(GetString(ZO_GetGamerCardStringId()), "EsoUI/Art/HUD/Gamepad/gp_radialIcon_gamercard_down.dds", "EsoUI/Art/HUD/Gamepad/gp_radialIcon_gamercard_down.dds",
-                                      function ()
-                                          ZO_ShowGamerCardFromDisplayNameOrFallback(targetDisplayName, ZO_ID_REQUEST_TYPE_CHARACTER_NAME, targetCharacterName)
-                                      end)
-    end
+    -- Do not override AddShowGamerCard: the gamer card flow calls private APIs
+    -- (GetConsoleInfoFromCharName). Let ZOS's implementation add the entry so
+    -- the callback runs in trusted context when ZO_IsConsoleOrGameCoreUI().
 end

--- a/LuiExtended/modules/ChatAnnouncements/ChatAnnouncementsPlayerToPlayerHooks.lua
+++ b/LuiExtended/modules/ChatAnnouncements/ChatAnnouncementsPlayerToPlayerHooks.lua
@@ -365,7 +365,7 @@ function ChatAnnouncements.PlayerToPlayerHook()
             local function DuelInviteOption()
                 ChallengeTargetToDuel(currentTargetCharacterName)
             end
-            local isEnabled = ENABLED_IF_NOT_IGNORED and (not ZO_IsConsoleOrGameCoreUI() or not IsCommunicationRestricted()) and isRestrictedCommunicationPermitted
+            local isEnabled = ENABLED_IF_NOT_IGNORED and isRestrictedCommunicationPermitted
             self:AddMenuEntry(GetString(SI_PLAYER_TO_PLAYER_INVITE_DUEL), platformIcons[SI_PLAYER_TO_PLAYER_INVITE_DUEL], isEnabled, isEnabled and DuelInviteOption or disabledOption)
         end
 
@@ -396,7 +396,7 @@ function ChatAnnouncements.PlayerToPlayerHook()
                 end
                 PlaySound(SOUNDS.GENERAL_ALERT_ERROR)
             end
-            local isEnabled = ENABLED_IF_NOT_IGNORED and not ZO_IsTributeLocked() and (not ZO_IsConsoleOrGameCoreUI() or not IsCommunicationRestricted()) and isRestrictedCommunicationPermitted
+            local isEnabled = ENABLED_IF_NOT_IGNORED and not ZO_IsTributeLocked() and isRestrictedCommunicationPermitted
             local entryFunction
             if isEnabled then
                 entryFunction = TributeInviteOption
@@ -412,7 +412,7 @@ function ChatAnnouncements.PlayerToPlayerHook()
         local function TradeInviteOption()
             TRADE_WINDOW:InitiateTrade(primaryNameInternal)
         end
-        local isEnabled = ENABLED_IF_NOT_IGNORED and (not ZO_IsConsoleOrGameCoreUI() or not IsCommunicationRestricted()) and isRestrictedCommunicationPermitted
+        local isEnabled = ENABLED_IF_NOT_IGNORED and isRestrictedCommunicationPermitted
         local tradeInviteFunction = isEnabled and TradeInviteOption or disabledOption
         self:AddMenuEntry(GetString(SI_PLAYER_TO_PLAYER_INVITE_TRADE), platformIcons[SI_PLAYER_TO_PLAYER_INVITE_TRADE], isEnabled, tradeInviteFunction)
 

--- a/LuiExtended/modules/ChatAnnouncements/ChatAnnouncementsPlayerToPlayerHooks.lua
+++ b/LuiExtended/modules/ChatAnnouncements/ChatAnnouncementsPlayerToPlayerHooks.lua
@@ -251,17 +251,9 @@ function ChatAnnouncements.PlayerToPlayerHook()
 
         -- Whisper
         if IsChatSystemAvailableForCurrentPlatform() then
-            local nameToUse = ZO_IsConsoleOrGameCoreUI() and currentTargetDisplayName or primaryNameInternal
+            local nameToUse = primaryNameInternal
             local function WhisperOption()
-                -- On console, call StartTextEntry directly with dontShowHUDWindow to avoid SetSetting security error
-                if ZO_IsConsoleOrGameCoreUI() then
-                    local chatSystem = ZO_GetChatSystem()
-                    if chatSystem then
-                        chatSystem:StartTextEntry(nil, CHAT_CHANNEL_WHISPER, nameToUse, true)
-                    end
-                else
-                    StartChatInput(nil, CHAT_CHANNEL_WHISPER, nameToUse)
-                end
+                StartChatInput(nil, CHAT_CHANNEL_WHISPER, nameToUse)
             end
             local isEnabled = ENABLED_IF_NOT_IGNORED and isRestrictedCommunicationPermitted
             local whisperFunction = isEnabled and WhisperOption or disabledOption
@@ -306,21 +298,17 @@ function ChatAnnouncements.PlayerToPlayerHook()
             self:AddMenuEntry(GetString(SI_PLAYER_TO_PLAYER_ADD_FRIEND), platformIcons[SI_PLAYER_TO_PLAYER_ADD_FRIEND], DISABLED, AlreadyFriendsWarning)
         else
             local function RequestFriendOption()
-                if ZO_IsConsoleOrGameCoreUI() then
-                    ZO_ShowConsoleAddFriendDialog(currentTargetCharacterName)
-                else
-                    RequestFriend(currentTargetDisplayName)
+                RequestFriend(currentTargetDisplayName)
 
-                    local displayNameLink = ZO_LinkHandler_CreateLink(currentTargetDisplayName, nil, DISPLAY_NAME_LINK_TYPE, currentTargetDisplayName)
-                    if ChatAnnouncements.SV.BracketOptionCharacter == 1 then
-                        displayNameLink = ZO_LinkHandler_CreateLinkWithoutBrackets(currentTargetDisplayName, nil, DISPLAY_NAME_LINK_TYPE, currentTargetDisplayName)
-                    end
+                local displayNameLink = ZO_LinkHandler_CreateLink(currentTargetDisplayName, nil, DISPLAY_NAME_LINK_TYPE, currentTargetDisplayName)
+                if ChatAnnouncements.SV.BracketOptionCharacter == 1 then
+                    displayNameLink = ZO_LinkHandler_CreateLinkWithoutBrackets(currentTargetDisplayName, nil, DISPLAY_NAME_LINK_TYPE, currentTargetDisplayName)
+                end
 
-                    local formattedMessage = zo_strformat(LUIE_STRING_SLASHCMDS_FRIEND_INVITE_MSG_LINK, displayNameLink)
+                local formattedMessage = zo_strformat(LUIE_STRING_SLASHCMDS_FRIEND_INVITE_MSG_LINK, displayNameLink)
 
-                    if ChatAnnouncements.SV.Social.FriendIgnoreAlert then
-                        ZO_Alert(UI_ALERT_CATEGORY_ALERT, SOUNDS.NONE, formattedMessage)
-                    end
+                if ChatAnnouncements.SV.Social.FriendIgnoreAlert then
+                    ZO_Alert(UI_ALERT_CATEGORY_ALERT, SOUNDS.NONE, formattedMessage)
                 end
             end
             self:AddMenuEntry(GetString(SI_PLAYER_TO_PLAYER_ADD_FRIEND), platformIcons[SI_PLAYER_TO_PLAYER_ADD_FRIEND], ENABLED_IF_NOT_IGNORED, ENABLED_IF_NOT_IGNORED and RequestFriendOption or AlertIgnored)


### PR DESCRIPTION
…d GameCore UI

- Replaced IsConsoleUI() checks with ZO_IsConsoleOrGameCoreUI() for improved compatibility across platforms.
- Adjusted ShowPlayerInteractMenu to delegate menu building to ZOS for trusted context on console.
- Removed the AddShowGamerCard function override to prevent private API calls, ensuring proper functionality.
- Enhanced communication option checks to account for console restrictions, improving user experience.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `ZO_PlayerToPlayer` interaction menu hooking and platform-conditional behavior; mistakes could break whisper/friend/group options on console/GameCore while remaining fine on PC.
> 
> **Overview**
> Updates player-to-player interaction hooking to be **console/GameCore safe**: replaces `IsConsoleUI()` checks with `ZO_IsConsoleOrGameCoreUI()` and, on those platforms, delegates `ZO_PlayerToPlayer:ShowPlayerInteractMenu` back to the original ZOS implementation to avoid taint/private API issues (notably Gamer Card).
> 
> Removes addon-side Gamer Card entry/override and simplifies whisper/friend flows to use the standard `StartChatInput`/`RequestFriend` paths (with existing alert/link messaging preserved).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cd1ea3723e8f8183569d5d6c6dc3bc89b5c4279. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->