### PR TITLE
feat: add player long-term buffs container and update settings

### DIFF
--- a/LuiExtended/console/settings/SpellCastBuffs.lua
+++ b/LuiExtended/console/settings/SpellCastBuffs.lua
@@ -293,6 +293,7 @@ function SpellCastBuffs.CreateConsoleSettings()
     {
         { key = "playerb", xKey = "playerbOffsetX", yKey = "playerbOffsetY", label = "Player Buffs",   disable = function () return Settings.lockPositionToUnitFrames end },
         { key = "playerd", xKey = "playerdOffsetX", yKey = "playerdOffsetY", label = "Player Debuffs", disable = function () return Settings.lockPositionToUnitFrames end },
+        { key = "player_long", xKey = "player_longOffsetX", yKey = "player_longOffsetY", label = "Player Long", disable = function () return false end },
         { key = "targetb", xKey = "targetbOffsetX", yKey = "targetbOffsetY", label = "Target Buffs",   disable = function () return Settings.lockPositionToUnitFrames end },
         { key = "targetd", xKey = "targetdOffsetX", yKey = "targetdOffsetY", label = "Target Debuffs", disable = function () return Settings.lockPositionToUnitFrames end },
     }
@@ -400,66 +401,6 @@ function SpellCastBuffs.CreateConsoleSettings()
                 default = 0,
             }
         end
-        -- Player Long (V or H based on alignVertical)
-        local function playerLongGetXY()
-            local vert = SpellCastBuffs.BuffContainers and SpellCastBuffs.BuffContainers.player_long and SpellCastBuffs.BuffContainers.player_long.alignVertical
-            local xKey = vert and "playerVOffsetX" or "playerHOffsetX"
-            local yKey = vert and "playerVOffsetY" or "playerHOffsetY"
-            return xKey, yKey
-        end
-        settings[#settings + 1] = { type = LHAS.ST_LABEL, label = "Player Long" }
-        settings[#settings + 1] =
-        {
-            type = LHAS.ST_SLIDER,
-            label = GetString(LUIE_STRING_LAM_UF_CFRAMES_POS_X),
-            tooltip = GetString(LUIE_STRING_LAM_UF_CFRAMES_POS_X_TP),
-            min = -gw,
-            max = gw,
-            step = 10,
-            getFunction = function ()
-                local xKey, _ = playerLongGetXY()
-                local v = Settings[xKey]
-                if v ~= nil then return v end
-                local c = SpellCastBuffs.BuffContainers and SpellCastBuffs.BuffContainers.player_long
-                return (c and c.GetLeft) and c:GetLeft() or 0
-            end,
-            setFunction = function (value)
-                local xKey, yKey = playerLongGetXY()
-                Settings[xKey] = value
-                if Settings[yKey] == nil then
-                    local c = SpellCastBuffs.BuffContainers and SpellCastBuffs.BuffContainers.player_long
-                    Settings[yKey] = (c and c.GetTop) and c:GetTop() or 0
-                end
-                SpellCastBuffs.SetTlwPosition()
-            end,
-            default = 0,
-        }
-        settings[#settings + 1] =
-        {
-            type = LHAS.ST_SLIDER,
-            label = GetString(LUIE_STRING_LAM_UF_CFRAMES_POS_Y),
-            tooltip = GetString(LUIE_STRING_LAM_UF_CFRAMES_POS_Y_TP),
-            min = -gh,
-            max = gh,
-            step = 10,
-            getFunction = function ()
-                local _, yKey = playerLongGetXY()
-                local v = Settings[yKey]
-                if v ~= nil then return v end
-                local c = SpellCastBuffs.BuffContainers and SpellCastBuffs.BuffContainers.player_long
-                return (c and c.GetTop) and c:GetTop() or 0
-            end,
-            setFunction = function (value)
-                local xKey, yKey = playerLongGetXY()
-                if Settings[xKey] == nil then
-                    local c = SpellCastBuffs.BuffContainers and SpellCastBuffs.BuffContainers.player_long
-                    Settings[xKey] = (c and c.GetLeft) and c:GetLeft() or 0
-                end
-                Settings[yKey] = value
-                SpellCastBuffs.SetTlwPosition()
-            end,
-            default = 0,
-        }
         -- Prominent Buffs (V or H based on alignVertical)
         local function prominentBGetXY()
             local vert = SpellCastBuffs.BuffContainers and SpellCastBuffs.BuffContainers.prominentbuffs and SpellCastBuffs.BuffContainers.prominentbuffs.alignVertical

--- a/LuiExtended/modules/SpellCastBuffs/SpellCastBuffs.lua
+++ b/LuiExtended/modules/SpellCastBuffs/SpellCastBuffs.lua
@@ -360,14 +360,8 @@ function SpellCastBuffs.Initialize(enabled)
 
     -- Separate container for players long term buffs
     CreateDraggableTopLevel("player_long", function (self)
-        local left, top = self:GetLeft(), self:GetTop()
-        if self.alignVertical then
-            SpellCastBuffs.SV.playerVOffsetX = left
-            SpellCastBuffs.SV.playerVOffsetY = top
-        else
-            SpellCastBuffs.SV.playerHOffsetX = left
-            SpellCastBuffs.SV.playerHOffsetY = top
-        end
+        SpellCastBuffs.SV.player_longOffsetX = self:GetLeft()
+        SpellCastBuffs.SV.player_longOffsetY = self:GetTop()
     end)
 
     SetContainerAlignVertical(SpellCastBuffs.BuffContainers.player_long, SpellCastBuffs.SV.LongTermEffectsSeparateAlignment)
@@ -379,6 +373,7 @@ function SpellCastBuffs.Initialize(enabled)
 
     -- Loop over table of fragments to add them to relevant UI Scenes
     RegisterFragmentsToScenes(fragments)
+    SpellCastBuffs.BuffFragments = fragments
 
     -- Set Buff Container Positions
     SpellCastBuffs.SetTlwPosition()
@@ -621,13 +616,8 @@ function SpellCastBuffs.ResetContainerOrientation()
     ---
     --- @param self TopLevelWindow|table
     local player_long_OnMoveStop = function (self)
-        if self.alignVertical then
-            SpellCastBuffs.SV.playerVOffsetX = self:GetLeft()
-            SpellCastBuffs.SV.playerVOffsetY = self:GetTop()
-        else
-            SpellCastBuffs.SV.playerHOffsetX = self:GetLeft()
-            SpellCastBuffs.SV.playerHOffsetY = self:GetTop()
-        end
+        SpellCastBuffs.SV.player_longOffsetX = self:GetLeft()
+        SpellCastBuffs.SV.player_longOffsetY = self:GetTop()
     end
     -- Separate container for players long term buffs
     SpellCastBuffs.BuffContainers.player_long:SetHandler("OnMoveStop", player_long_OnMoveStop)
@@ -835,6 +825,8 @@ function SpellCastBuffs.ResetTlwPosition()
     SpellCastBuffs.SV.targetbOffsetY = nil
     SpellCastBuffs.SV.targetdOffsetX = nil
     SpellCastBuffs.SV.targetdOffsetY = nil
+    SpellCastBuffs.SV.player_longOffsetX = nil
+    SpellCastBuffs.SV.player_longOffsetY = nil
     SpellCastBuffs.SV.playerVOffsetX = nil
     SpellCastBuffs.SV.playerVOffsetY = nil
     SpellCastBuffs.SV.playerHOffsetX = nil
@@ -939,12 +931,11 @@ function SpellCastBuffs.SetTlwPosition()
     end
 
     if SpellCastBuffs.BuffContainers.player_long then
-        ApplyDualAlignmentTlwPosition(
+        ApplySimpleTlwPosition(
             SpellCastBuffs.BuffContainers.player_long,
-            SpellCastBuffs.SV.playerVOffsetX, SpellCastBuffs.SV.playerVOffsetY,
-            SpellCastBuffs.SV.playerHOffsetX, SpellCastBuffs.SV.playerHOffsetY,
-            DefaultAnchor(BOTTOMRIGHT, GuiRoot, BOTTOMRIGHT, -3, -75),
-            DefaultAnchor(BOTTOM, ZO_PlayerAttributeHealth, TOP, 0, -70)
+            SpellCastBuffs.SV.player_longOffsetX,
+            SpellCastBuffs.SV.player_longOffsetY,
+            RIGHT, GuiRoot, RIGHT, 0, 0
         )
     end
 
@@ -973,6 +964,18 @@ end
 function SpellCastBuffs.SetMovingState(state)
     if not SpellCastBuffs.Enabled then
         return
+    end
+
+    -- When unlocked on console, add buff fragments to settings scene so frames are visible while addon settings are open
+    if IsConsoleUI() and SpellCastBuffs.BuffFragments then
+        local settingsScene = sceneManager:GetScene("LibHarvensAddonSettingsScene")
+        for _, fragment in pairs(SpellCastBuffs.BuffFragments) do
+            if state then
+                settingsScene:AddFragment(fragment)
+            else
+                settingsScene:RemoveFragment(fragment)
+            end
+        end
     end
 
     local function UpdatePositionLabel(control, label)
@@ -1035,14 +1038,9 @@ function SpellCastBuffs.SetMovingState(state)
     end
 
     if SpellCastBuffs.BuffContainers.player_long then
-        SetContainerMovingState(SpellCastBuffs.BuffContainers.player_long, function (self, left, top)
-            if self.alignVertical then
-                SpellCastBuffs.SV.playerVOffsetX = left
-                SpellCastBuffs.SV.playerVOffsetY = top
-            else
-                SpellCastBuffs.SV.playerHOffsetX = left
-                SpellCastBuffs.SV.playerHOffsetY = top
-            end
+        SetContainerMovingState(SpellCastBuffs.BuffContainers.player_long, function (_, left, top)
+            SpellCastBuffs.SV.player_longOffsetX = left
+            SpellCastBuffs.SV.player_longOffsetY = top
         end)
     end
 


### PR DESCRIPTION
- Introduced a new container for player long-term buffs, allowing for better management and positioning.
- Updated console settings to include options for the new player long-term buffs, enhancing user customization.
- Refactored position handling to streamline the alignment logic for the new container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how `player_long` positions are saved/applied (new SV keys replacing prior H/V offsets), which could shift existing users’ layouts or require migration/reset. Also adjusts scene fragment handling during move/unlock on console, affecting UI visibility in settings scenes.
> 
> **Overview**
> Adds console settings sliders for the `player_long` (long-term player buffs) container using new saved variables `player_longOffsetX/Y`, and removes the prior special-case logic that stored separate horizontal/vertical offsets.
> 
> Updates `SpellCastBuffs` to persist/apply `player_long` position via the new single offset pair (including reset behavior and a new default anchor), stores created buff fragments on init, and on console temporarily adds/removes those fragments to the settings scene when unlocking frames so containers remain visible while repositioning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d84973b90ace81c5603de3b8ad85b36c790fd5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->