### PR TITLE
vbump

### DIFF
--- a/LuiExtended/LuiExtended.addon
+++ b/LuiExtended/LuiExtended.addon
@@ -2,8 +2,8 @@
 ## Author: @dack_janiels[PC]
 ## LegacyAuthors: ArtOfShred, psypanda, Saenic & SpellBuilder
 ## APIVersion: 101049 101050
-## Version: 7.2.0.2
-## AddOnVersion: 7202
+## Version: 7.2.0.3
+## AddOnVersion: 7203
 ## Description: Provides UnitFrames, InfoPanel, Combat Text & Info, Buff & Debuff Tracking, Chat Announcements and Slash Commands.
 ## DependsOn: LuiMedia>=7131 LuiData>=7205
 ## PCDependsOn: LibAddonMenu-2.0>=41

--- a/LuiExtended/src/LuiExtended.lua
+++ b/LuiExtended/src/LuiExtended.lua
@@ -28,8 +28,8 @@ local LUIE = LUIE
 -- -----------------------------------------------------------------------------
 LUIE.tag = "LUIE"
 LUIE.name = "LuiExtended"
-LUIE.version = "7.2.0.2"
-LUIE.addonVersion = 7202
+LUIE.version = "7.2.0.3"
+LUIE.addonVersion = 7203
 LUIE.author = "@dack_janiels[PC]"
 LUIE.legacyAuthors = "ArtOfShred, psypanda, Saenic & SpellBuilder"
 LUIE.website = "https://www.esoui.com/downloads/info818-LuiExtended.html"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that just increments the add-on version identifiers; no functional logic is modified.
> 
> **Overview**
> Bumps the add-on version from `7.2.0.2` (`7202`) to `7.2.0.3` (`7203`) in both the manifest (`LuiExtended.addon`) and the runtime constants (`src/LuiExtended.lua`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5e8cd60b0ee056e92ffb19709ac54de49dd81fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->